### PR TITLE
docs: sync README plan example and tree with v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ assignee_model: ""
 backlog_date: "YYYY-MM-DDThh:mm"
 doing_date: ""
 done_date: ""
-format_version: "0.2.1"
+format_version: "0.3.0"
 ---
 
 # User authentication setup
+
+## Objective
+Brief description of what this plan aims to achieve and why.
 
 ## Progress
 ### Phase 1: Definition
@@ -52,9 +55,6 @@ format_version: "0.2.1"
 ### Phase 3: Closing
 - [ ] Write Closing Summary
 - [ ] Validate implementation with the user
-
-## Objective
-Brief description of what this plan aims to achieve and why.
 
 ## Context
 Relevant background, constraints, or references that inform the plan.
@@ -96,6 +96,7 @@ workplans/
 ├── backlog/       # Pending plans
 ├── doing/         # Work in progress
 ├── done/          # Completed plans
+├── extend/        # Optional extensions (created on demand)
 ├── README.md      # General info
 └── RULES.md       # Framework rules (source of truth)
 ```


### PR DESCRIPTION
## Summary

- Update the plan example in **What is a plan?** to the v0.3.0 layout: `Objective` is now placed above `Progress`, and `format_version` is bumped to `"0.3.0"`.
- Add the optional `extend/` directory to the folder tree in **Quick start** so it matches the v0.3.0 structure shipped in `init/`.

## Why

The v0.3.0 release moved `Objective` above `Progress` (rule 9) and introduced the optional `extend/` folder, but the public README was still showing the legacy v0.2.x layout and tree. This is a docs-only sync — no rule or behavior changes.

## Test plan

- [x] Render the README on GitHub and confirm the plan example matches `init/workplans/RULES.md` section order.
- [x] Confirm the folder tree includes `extend/`.