### PR TITLE
feat(cli): workplans CLI v0.1.0 (init + update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,36 @@ _To be written when the last phase is completed._
 
 ### 1. Download the workplans folder
 
-#### Option A: From GitHub
+#### Option A: With the workplans CLI (recommended)
+If you have Node.js installed, open the terminal in your project folder and run:
+
+```bash
+npx workplans init
+```
+
+This is non-destructive — it fails with a clear error if a `workplans/` folder already exists in the current directory. To refresh `RULES.md` and `README.md` later when a new framework release ships, run:
+
+```bash
+npx workplans update
+```
+
+`update` refreshes only the framework system files. Your plans inside `backlog/`, `doing/`, and `done/` are never touched.
+
+#### Option B: From GitHub
 Download the `.zip`, extract it, and copy the `workplans` folder (inside `init/`) into your project.
 
 [![Download latest release](https://img.shields.io/github/v/release/agnostical/workplans?label=Download&style=for-the-badge&logo=github)](https://github.com/agnostical/workplans/releases/latest)
 
-#### Option B: Using the terminal
-If you have Node.js installed, open the terminal in your project folder and run:
+#### Option C: Using giget directly
+If you prefer not to install the CLI, you can use `giget`:
 
 ```bash
 npx giget gh:agnostical/workplans/init . --force
 ```
 
-Both options give you the same ready-to-use folder with three state directories for your plans and a RULES.md that acts as the source of truth for your AI agent:
+Note: this overwrites all files unconditionally, including existing plans. Use Option A for safer updates.
+
+All three options give you the same ready-to-use folder with three state directories for your plans and a RULES.md that acts as the source of truth for your AI agent:
 
 ```
 workplans/

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,37 @@
+# workplans
+
+CLI for the [Workplans framework](https://github.com/agnostical/workplans) — install and update markdown plan structures for AI agents.
+
+## Install
+
+```bash
+npx workplans init
+```
+
+This scaffolds a `workplans/` folder in the current directory with `RULES.md`, `README.md`, and the `backlog/`, `doing/`, `done/` state folders.
+
+## Commands
+
+```bash
+npx workplans init     # Scaffold the framework (fails if workplans/ already exists)
+npx workplans update   # Refresh RULES.md and README.md, ensure state folders exist
+                       # User plans are never touched
+```
+
+### Flags
+
+- `-h`, `--help` — show usage
+- `-V`, `--version` — show version
+
+## Versioning
+
+This CLI tool versions independently from the Workplans framework format spec. `workplans@0.1.x` is a CLI release; the framework format is versioned in [`RULES.md`](https://github.com/agnostical/workplans/blob/main/init/workplans/RULES.md) and bumped separately when the plan format changes.
+
+## Links
+
+- [Workplans framework repository](https://github.com/agnostical/workplans)
+- [Issues](https://github.com/agnostical/workplans/issues)
+
+## License
+
+MIT

--- a/cli/bin/cli.mjs
+++ b/cli/bin/cli.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runInit } from "../commands/init.mjs";
+import { runUpdate } from "../commands/update.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
+
+const HELP = `workplans v${pkg.version}
+
+Usage:
+  npx workplans <command>
+
+Commands:
+  init      Scaffold the workplans framework in the current directory
+  update    Refresh RULES.md/README.md and ensure state folders exist
+            (never touches user plans)
+
+Options:
+  -h, --help     Show this help
+  -V, --version  Show version
+
+More: https://github.com/agnostical/workplans`;
+
+async function main() {
+  const arg = process.argv[2];
+
+  if (!arg || arg === "-h" || arg === "--help") {
+    console.log(HELP);
+    return;
+  }
+
+  if (arg === "-V" || arg === "--version") {
+    console.log(pkg.version);
+    return;
+  }
+
+  try {
+    switch (arg) {
+      case "init":
+        await runInit();
+        break;
+      case "update":
+        await runUpdate();
+        break;
+      default:
+        console.error(`Unknown command: ${arg}\n`);
+        console.error(HELP);
+        process.exit(1);
+    }
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/cli/commands/init.mjs
+++ b/cli/commands/init.mjs
@@ -1,0 +1,38 @@
+import { existsSync } from "node:fs";
+import { cp, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { downloadTemplate } from "giget";
+
+export async function runInit() {
+  const target = resolve(process.cwd(), "workplans");
+
+  if (existsSync(target)) {
+    throw new Error(
+      "workplans/ already exists in the current directory.\n" +
+      "Did you mean 'npx workplans update'?"
+    );
+  }
+
+  console.log("Scaffolding workplans framework...");
+
+  const tempDir = await mkdtemp(join(tmpdir(), "workplans-init-"));
+
+  try {
+    await downloadTemplate("gh:agnostical/workplans/init", {
+      dir: tempDir,
+      force: true,
+    });
+
+    await cp(join(tempDir, "workplans"), target, { recursive: true });
+
+    console.log("");
+    console.log("Done. workplans/ created.");
+    console.log("");
+    console.log("Next steps:");
+    console.log("  - Read workplans/README.md");
+    console.log("  - Create your first plan in workplans/backlog/");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}

--- a/cli/commands/update.mjs
+++ b/cli/commands/update.mjs
@@ -1,0 +1,50 @@
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { downloadTemplate } from "giget";
+
+const SYSTEM_FILES = ["RULES.md", "README.md"];
+const STATE_FOLDERS = ["backlog", "doing", "done"];
+
+export async function runUpdate() {
+  const workplansDir = resolve(process.cwd(), "workplans");
+
+  if (!existsSync(workplansDir)) {
+    throw new Error(
+      "workplans/ not found in the current directory.\n" +
+      "Did you mean 'npx workplans init'?"
+    );
+  }
+
+  console.log("Updating workplans framework...");
+
+  const tempDir = await mkdtemp(join(tmpdir(), "workplans-update-"));
+
+  try {
+    await downloadTemplate("gh:agnostical/workplans/init", {
+      dir: tempDir,
+      force: true,
+    });
+
+    const sourceDir = join(tempDir, "workplans");
+
+    for (const file of SYSTEM_FILES) {
+      await copyFile(join(sourceDir, file), join(workplansDir, file));
+      console.log(`  Updated workplans/${file}`);
+    }
+
+    for (const folder of STATE_FOLDERS) {
+      const target = join(workplansDir, folder);
+      if (!existsSync(target)) {
+        await mkdir(target, { recursive: true });
+        console.log(`  Created workplans/${folder}/`);
+      }
+    }
+
+    console.log("");
+    console.log("Done. User plans were not modified.");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "workplans",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "workplans",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "giget": "^3.1.2"
+      },
+      "bin": {
+        "workplans": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/giget": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
+      "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "workplans",
+  "version": "0.1.0",
+  "description": "CLI for the Workplans framework — install and update markdown plan structures for AI agents.",
+  "type": "module",
+  "bin": {
+    "workplans": "./bin/cli.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin/",
+    "commands/",
+    "README.md"
+  ],
+  "keywords": [
+    "workplans",
+    "cli",
+    "ai-agents",
+    "scaffolding",
+    "framework",
+    "plans"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agnostical/workplans.git",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/agnostical/workplans/tree/main/cli#readme",
+  "bugs": "https://github.com/agnostical/workplans/issues",
+  "author": "Sebastian Serna",
+  "license": "MIT",
+  "dependencies": {
+    "giget": "^3.1.2"
+  }
+}


### PR DESCRIPTION
## Summary

First release of the `workplans` npm CLI. Ships `init` and `update` commands as the recommended way to scaffold and refresh the framework, replacing the `npx giget --force` flow which is not safe to re-run.

Closes #48.

## What's included

- `cli/` subfolder with `package.json`, `bin/cli.mjs`, `commands/init.mjs`, `commands/update.mjs`
- Thin wrapper over giget (single runtime dependency, `^3.1.2`)
- Non-destructive guarantees:
  - `init` fails with a clear error if `workplans/` already exists
  - `update` only refreshes `RULES.md` and `README.md`, ensures state folders exist, **never touches user plans**
- `--help` and `--version` flags
- `cli/README.md` as the npm package page
- Repo `README.md` Quick start updated to recommend `npx workplans init`

## Versioning

This CLI publishes as `workplans@0.1.0` on npm with its own SemVer. It does **not** bump `RULES.md` or tag the repo — framework format versioning stays in `RULES.md` and bumps only on format spec changes.

## Out of scope (deferred to v0.2.0)

- Template system (`list`, `add <template>`) — tracked in #55

## Test plan

Manual end-to-end testing in temp directories:

- [x] `init` in clean dir → creates `workplans/` with all framework files
- [x] `init` with existing `workplans/` → exits 1 with clear error, suggests `update`
- [x] `update` with user plan in backlog → refreshes system files, user plan intact
- [x] `update` without `workplans/` → exits 1 with clear error, suggests `init`
- [x] `update` recreates missing state folder (`done/` after manual deletion)
- [x] `--help`, `--version`, unknown command (exit 1)

## Follow-up after merge

- Publish to npm as `workplans@0.1.0` (from `cli/`)
- Close milestone `cli-v0.1.0`