### PR TITLE
feat(cli): release v0.1.1 with version check and state folder README fix

### DIFF
--- a/cli/commands/update.mjs
+++ b/cli/commands/update.mjs
@@ -18,6 +18,7 @@ export async function runUpdate() {
   }
 
   console.log("Updating workplans framework...");
+  console.log("  Downloading template from gh:agnostical/workplans/init...");
 
   const tempDir = await mkdtemp(join(tmpdir(), "workplans-update-"));
 
@@ -40,6 +41,11 @@ export async function runUpdate() {
         await mkdir(target, { recursive: true });
         console.log(`  Created workplans/${folder}/`);
       }
+      await copyFile(
+        join(sourceDir, folder, "README.md"),
+        join(target, "README.md")
+      );
+      console.log(`  Updated workplans/${folder}/README.md`);
     }
 
     console.log("");

--- a/cli/commands/update.mjs
+++ b/cli/commands/update.mjs
@@ -1,11 +1,21 @@
 import { existsSync } from "node:fs";
-import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { downloadTemplate } from "giget";
 
 const SYSTEM_FILES = ["RULES.md", "README.md"];
 const STATE_FOLDERS = ["backlog", "doing", "done"];
+
+async function readFrameworkVersion(rulesPath) {
+  if (!existsSync(rulesPath)) return null;
+  const content = await readFile(rulesPath, "utf8");
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatter) return null;
+  const versionLine = frontmatter[1].match(/^version:\s*(.+)$/m);
+  if (!versionLine) return null;
+  return versionLine[1].trim().replace(/^["']|["']$/g, "");
+}
 
 export async function runUpdate() {
   const workplansDir = resolve(process.cwd(), "workplans");
@@ -29,6 +39,14 @@ export async function runUpdate() {
     });
 
     const sourceDir = join(tempDir, "workplans");
+    const remoteVersion = await readFrameworkVersion(join(sourceDir, "RULES.md"));
+    const localVersion = await readFrameworkVersion(join(workplansDir, "RULES.md"));
+
+    if (remoteVersion && localVersion && remoteVersion === localVersion) {
+      console.log("");
+      console.log(`Workplans framework is already up to date (v${localVersion}).`);
+      return;
+    }
 
     for (const file of SYSTEM_FILES) {
       await copyFile(join(sourceDir, file), join(workplansDir, file));
@@ -49,7 +67,13 @@ export async function runUpdate() {
     }
 
     console.log("");
-    console.log("Done. User plans were not modified.");
+    if (remoteVersion && localVersion) {
+      console.log(`Updated to v${remoteVersion} (from v${localVersion}). User plans were not modified.`);
+    } else if (remoteVersion) {
+      console.log(`Updated to v${remoteVersion}. User plans were not modified.`);
+    } else {
+      console.log("Done. User plans were not modified.");
+    }
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workplans",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI for the Workplans framework — install and update markdown plan structures for AI agents.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- **fix:** `update` command now refreshes the `README.md` files inside `backlog/`, `doing/` and `done/` — previously only `workplans/RULES.md` and `workplans/README.md` were updated, leaving state folder READMEs stale forever.
- **feat:** `update` reads the `version` field from the YAML frontmatter of `RULES.md` (both local install and downloaded template). If they match, it prints `Workplans framework is already up to date (vX.Y.Z)` and exits without overwriting any files. When they differ, the success message reports the version transition (`Updated to v0.3.0 (from v0.2.0)`). Legacy installs without a version frontmatter are treated as unknown and updated as before.
- **chore:** bump CLI to `v0.1.1`.

User plans in `backlog/`, `doing/` and `done/` are never touched — only the framework `README.md` files inside each state folder are overwritten.

## Test plan

- [x] `update` against a workplans install already at the latest version → prints `already up to date`, no files modified.
- [x] `update` against a workplans install with an older `version:` in `RULES.md` → copies all 5 framework files, reports the version transition.
- [x] `update` against a legacy install without `version:` frontmatter in `RULES.md` → updates and prints generic success message.
- [x] User plans in `backlog/` and `done/` are untouched across all scenarios (verified via `git status` on a real downstream repo).
- [x] After merge: publish to npm with `npm publish` from `cli/` to make `npx workplans update` use the new logic.