### PR TITLE
docs: make Phase 1 and Closing translation rule explicit

### DIFF
--- a/demo/workplans/RULES.md
+++ b/demo/workplans/RULES.md
@@ -136,7 +136,7 @@ H1 is the first line after the frontmatter and must match `title` exactly. One H
 
 ### Mandatory phases
 
-Every plan must start with **Phase 1: Definition** (entry gate) and end with a **Closing** phase (exit gate). Steps in both are fixed and must not be modified:
+Every plan must start with **Phase 1: Definition** (entry gate) and end with a **Closing** phase (exit gate). The structure, action, and order of steps in both are fixed — but the phase name and step text translate to the user's active conversation language (only the `Phase N:` prefix and the H2 headings remain English):
 
 ```markdown
 ### Phase 1: Definition
@@ -149,13 +149,26 @@ Every plan must start with **Phase 1: Definition** (entry gate) and end with a *
 - [ ] Validate implementation with the user
 ```
 
+The same template applied in Spanish (`Closing Summary` stays in English inside step text because it references the exact H2 section name, which is always English):
+
+```markdown
+### Phase 1: Definición
+- [ ] Definir objetivo y contexto
+- [ ] Definir fases y pasos
+- [ ] Refinar con el usuario
+
+### Phase N: Cierre
+- [ ] Escribir Closing Summary
+- [ ] Validar implementación con el usuario
+```
+
 A plan in `backlog/` with Phase 1 unchecked is still being defined. A plan cannot move to `doing/` until all three steps are checked. A plan cannot move to `done/` until both Closing steps are checked and the user has explicitly approved.
 
-The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions, translated to the user's language: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` respectively. Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
+The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions that also translate to the user's language. English canonical: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` The same entries in Spanish: `Define el Objective, el Context y las fases subsiguientes. Una vez completas, el plan queda listo para ejecución.` and `Valida la implementación con el usuario y escribe el Closing Summary. Una vez completa, el plan queda listo para moverse a done.` Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
 
 ## Rules
 
-All 26 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 27 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -185,6 +198,7 @@ All 26 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 24 | Template | Plan files must not contain emojis. Use plain descriptive text instead |
 | 25 | Template | Steps that cannot be executed by an AI agent (browser checks, external dashboard configuration, manual UI testing, credential rotation) must be prefixed with `[manual]`. The agent skips them and reports to the user; Implementation describes what the user needs to do |
 | 26 | Structure | When the workplans folder is inside a Git repository (or any VCS with branch semantics), the branch for a new plan is decided explicitly before commit: declared policy in agent file → current non-main branch → ask the user. Never default silently to `main`. Outside a VCS, this rule does not apply |
+| 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language. Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
 
 ## File naming
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -136,7 +136,7 @@ H1 is the first line after the frontmatter and must match `title` exactly. One H
 
 ### Mandatory phases
 
-Every plan must start with **Phase 1: Definition** (entry gate) and end with a **Closing** phase (exit gate). Steps in both are fixed and must not be modified:
+Every plan must start with **Phase 1: Definition** (entry gate) and end with a **Closing** phase (exit gate). The structure, action, and order of steps in both are fixed — but the phase name and step text translate to the user's active conversation language (only the `Phase N:` prefix and the H2 headings remain English):
 
 ```markdown
 ### Phase 1: Definition
@@ -149,13 +149,26 @@ Every plan must start with **Phase 1: Definition** (entry gate) and end with a *
 - [ ] Validate implementation with the user
 ```
 
+The same template applied in Spanish (`Closing Summary` stays in English inside step text because it references the exact H2 section name, which is always English):
+
+```markdown
+### Phase 1: Definición
+- [ ] Definir objetivo y contexto
+- [ ] Definir fases y pasos
+- [ ] Refinar con el usuario
+
+### Phase N: Cierre
+- [ ] Escribir Closing Summary
+- [ ] Validar implementación con el usuario
+```
+
 A plan in `backlog/` with Phase 1 unchecked is still being defined. A plan cannot move to `doing/` until all three steps are checked. A plan cannot move to `done/` until both Closing steps are checked and the user has explicitly approved.
 
-The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions, translated to the user's language: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` respectively. Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
+The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions that also translate to the user's language. English canonical: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` The same entries in Spanish: `Define el Objective, el Context y las fases subsiguientes. Una vez completas, el plan queda listo para ejecución.` and `Valida la implementación con el usuario y escribe el Closing Summary. Una vez completa, el plan queda listo para moverse a done.` Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
 
 ## Rules
 
-All 26 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 27 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -185,6 +198,7 @@ All 26 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 24 | Template | Plan files must not contain emojis. Use plain descriptive text instead |
 | 25 | Template | Steps that cannot be executed by an AI agent (browser checks, external dashboard configuration, manual UI testing, credential rotation) must be prefixed with `[manual]`. The agent skips them and reports to the user; Implementation describes what the user needs to do |
 | 26 | Structure | When the workplans folder is inside a Git repository (or any VCS with branch semantics), the branch for a new plan is decided explicitly before commit: declared policy in agent file → current non-main branch → ask the user. Never default silently to `main`. Outside a VCS, this rule does not apply |
+| 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language. Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
 
 ## File naming
 


### PR DESCRIPTION
Closes #59.

Removes the recurring error source where agents copy the Phase 1 and Closing template in literal English, ignoring that the phase name and step text translate to the user's active conversation language.

Four changes in RULES.md (source in init/, demo/ regenerated):

1. The ambiguous sentence "Steps in both are fixed and must not be modified" is replaced by the explicit version: structure, action and order are fixed, but the phase name and step text translate (only the `Phase N:` prefix and the H2 headings remain English).
2. A second code block shows the template applied in Spanish next to the English canonical — agents copy from visible examples, and two versions side by side prevent the error at the source. Includes the note that `Closing Summary` keeps its English form inside a step because it references the exact H2 section name.
3. The Implementation entries for Phase 1 and Closing now show the English canonical and the Spanish translation side by side.
4. New numbered rule **#27** (Template category) making the translation rule explicit; the preamble goes from 26 to 27 rules. Appended instead of inserted to avoid renumbering — existing rule numbers (18, 23, 26) are cited across issues and plans.

**Empirical validation**: a fresh agent with no prior context, given this RULES.md, produced a Spanish plan with "Phase 1: Definición" and "Cierre" correctly translated and `Closing Summary` kept in English inside the step, on the first try.

validate.sh passes on init/ and demo/ (0 errors, 0 warnings).

Documentation-only change, no new behavior — targets release v0.3.1.