### PR TITLE
chore: bump framework version to 0.3.1

### DIFF
--- a/demo/workplans/RULES.md
+++ b/demo/workplans/RULES.md
@@ -1,6 +1,6 @@
 ---
 name: workplans
-version: 0.3.0
+version: 0.3.1
 work_on: "."
 ---
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -1,6 +1,6 @@
 ---
 name: workplans
-version: 0.3.0
+version: 0.3.1
 work_on: "."
 ---
 


### PR DESCRIPTION
Version bump for the v0.3.1 patch release (milestone [v0.3.1](https://github.com/agnostical/workplans/milestone/8)).

- `version: 0.3.0` -> `0.3.1` in `init/workplans/RULES.md`; `demo/` regenerated with `build-demo.sh`.
- Content shipped in #74 (closes #59): the Phase 1 / Closing translation rule made explicit, new rule 27.
- Documentation-only patch: no format changes, no migration. Plans created from now on declare `format_version: "0.3.1"`; validators apply the same rule set as 0.3.0.

After merge: tag `v0.3.1`, GitHub release, close the milestone.