### PR TITLE
refactor: CLI hardening — tests, semver, extensible router, network errors

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,0 +1,27 @@
+name: CLI publish
+
+# Publishes the npm package when a GitHub release with a cli-v* tag is created.
+# Requires the NPM_TOKEN repository secret.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    if: startsWith(github.event.release.tag_name, 'cli-v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -1,0 +1,22 @@
+name: CLI tests
+
+on:
+  push:
+    branches: [main]
+    paths: ["cli/**"]
+  pull_request:
+    paths: ["cli/**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/cli/bin/cli.mjs
+++ b/cli/bin/cli.mjs
@@ -3,33 +3,67 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { runInit } from "../commands/init.mjs";
-import { runUpdate } from "../commands/update.mjs";
+import { installSigintCleanup } from "../lib/download.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
 
-const HELP = `workplans v${pkg.version}
+/**
+ * Command registry. Adding a command is one entry here plus one module in
+ * commands/ — the router needs no other change.
+ *   load        dynamic import of the command module
+ *   fn          exported function to run
+ *   positionals number of positional arguments after the command name
+ *   summary     one-line description for --help
+ */
+const registry = new Map([
+  [
+    "init",
+    {
+      load: () => import("../commands/init.mjs"),
+      fn: "runInit",
+      positionals: 0,
+      summary: "Scaffold the workplans framework in the current directory",
+    },
+  ],
+  [
+    "update",
+    {
+      load: () => import("../commands/update.mjs"),
+      fn: "runUpdate",
+      positionals: 0,
+      summary:
+        "Refresh RULES.md/README.md and ensure state folders exist (never touches user plans)",
+    },
+  ],
+]);
+
+function buildHelp() {
+  const lines = [...registry.entries()].map(
+    ([name, cmd]) => `  ${name.padEnd(10)}${cmd.summary}`
+  );
+  return `workplans v${pkg.version}
 
 Usage:
   npx workplans <command>
 
 Commands:
-  init      Scaffold the workplans framework in the current directory
-  update    Refresh RULES.md/README.md and ensure state folders exist
-            (never touches user plans)
+${lines.join("\n")}
 
 Options:
   -h, --help     Show this help
   -V, --version  Show version
 
 More: https://github.com/agnostical/workplans`;
+}
 
 async function main() {
-  const arg = process.argv[2];
+  installSigintCleanup();
+
+  const [arg, ...rest] = process.argv.slice(2);
 
   if (!arg || arg === "-h" || arg === "--help") {
-    console.log(HELP);
+    console.log(buildHelp());
     return;
   }
 
@@ -38,19 +72,24 @@ async function main() {
     return;
   }
 
+  const command = registry.get(arg);
+  if (!command) {
+    console.error(`Unknown command: ${arg}\n`);
+    console.error(buildHelp());
+    process.exit(1);
+  }
+
+  if (rest.length !== command.positionals) {
+    console.error(
+      `'${arg}' expects ${command.positionals} argument(s), got ${rest.length}.\n`
+    );
+    console.error(buildHelp());
+    process.exit(1);
+  }
+
   try {
-    switch (arg) {
-      case "init":
-        await runInit();
-        break;
-      case "update":
-        await runUpdate();
-        break;
-      default:
-        console.error(`Unknown command: ${arg}\n`);
-        console.error(HELP);
-        process.exit(1);
-    }
+    const mod = await command.load();
+    await mod[command.fn](...rest);
   } catch (err) {
     console.error(`Error: ${err.message}`);
     process.exit(1);

--- a/cli/commands/init.mjs
+++ b/cli/commands/init.mjs
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { cp, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { downloadTemplate } from "giget";
+import { downloadInit, registerTempDir, unregisterTempDir } from "../lib/download.mjs";
 
 export async function runInit() {
   const target = resolve(process.cwd(), "workplans");
@@ -17,14 +17,22 @@ export async function runInit() {
   console.log("Scaffolding workplans framework...");
 
   const tempDir = await mkdtemp(join(tmpdir(), "workplans-init-"));
+  registerTempDir(tempDir);
 
   try {
-    await downloadTemplate("gh:agnostical/workplans/init", {
-      dir: tempDir,
-      force: true,
-    });
+    await downloadInit(tempDir);
 
-    await cp(join(tempDir, "workplans"), target, { recursive: true });
+    try {
+      await cp(join(tempDir, "workplans"), target, { recursive: true });
+    } catch (err) {
+      if (err.code === "EACCES" || err.code === "EPERM") {
+        throw new Error(
+          "Permission denied writing to the current directory.\n" +
+          "Check that you have write permissions here and try again."
+        );
+      }
+      throw err;
+    }
 
     console.log("");
     console.log("Done. workplans/ created.");
@@ -33,6 +41,7 @@ export async function runInit() {
     console.log("  - Read workplans/README.md");
     console.log("  - Create your first plan in workplans/backlog/");
   } finally {
+    unregisterTempDir(tempDir);
     await rm(tempDir, { recursive: true, force: true });
   }
 }

--- a/cli/commands/update.mjs
+++ b/cli/commands/update.mjs
@@ -2,19 +2,37 @@ import { existsSync } from "node:fs";
 import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { downloadTemplate } from "giget";
+import { compareVersions } from "../lib/semver.mjs";
+import {
+  downloadInit,
+  fetchRemoteVersion,
+  readVersionFromRules,
+  registerTempDir,
+  unregisterTempDir,
+} from "../lib/download.mjs";
 
 const SYSTEM_FILES = ["RULES.md", "README.md"];
 const STATE_FOLDERS = ["backlog", "doing", "done"];
 
-async function readFrameworkVersion(rulesPath) {
+async function readLocalVersion(rulesPath) {
   if (!existsSync(rulesPath)) return null;
-  const content = await readFile(rulesPath, "utf8");
-  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!frontmatter) return null;
-  const versionLine = frontmatter[1].match(/^version:\s*(.+)$/m);
-  if (!versionLine) return null;
-  return versionLine[1].trim().replace(/^["']|["']$/g, "");
+  return readVersionFromRules(await readFile(rulesPath, "utf8"));
+}
+
+function reportSkip(cmp, localVersion, remoteVersion) {
+  if (cmp === 0) {
+    console.log("");
+    console.log(`Workplans framework is already up to date (v${localVersion}).`);
+    return true;
+  }
+  if (cmp === -1) {
+    console.log("");
+    console.log(
+      `Local version (v${localVersion}) is newer than remote (v${remoteVersion}). Nothing to do.`
+    );
+    return true;
+  }
+  return false;
 }
 
 export async function runUpdate() {
@@ -28,42 +46,63 @@ export async function runUpdate() {
   }
 
   console.log("Updating workplans framework...");
-  console.log("  Downloading template from gh:agnostical/workplans/init...");
 
+  const localVersion = await readLocalVersion(join(workplansDir, "RULES.md"));
+
+  // Cheap remote version check first: skip the full download when there is
+  // nothing to update. Best effort — on failure we fall through to download.
+  if (localVersion) {
+    const remoteVersion = await fetchRemoteVersion();
+    if (remoteVersion && reportSkip(compareVersions(remoteVersion, localVersion), localVersion, remoteVersion)) {
+      return;
+    }
+  }
+
+  console.log("  Downloading template...");
   const tempDir = await mkdtemp(join(tmpdir(), "workplans-update-"));
+  registerTempDir(tempDir);
 
   try {
-    await downloadTemplate("gh:agnostical/workplans/init", {
-      dir: tempDir,
-      force: true,
-    });
+    await downloadInit(tempDir);
 
     const sourceDir = join(tempDir, "workplans");
-    const remoteVersion = await readFrameworkVersion(join(sourceDir, "RULES.md"));
-    const localVersion = await readFrameworkVersion(join(workplansDir, "RULES.md"));
+    const remoteVersion = await readLocalVersion(join(sourceDir, "RULES.md"));
 
-    if (remoteVersion && localVersion && remoteVersion === localVersion) {
-      console.log("");
-      console.log(`Workplans framework is already up to date (v${localVersion}).`);
+    // Authoritative comparison against the downloaded template.
+    if (
+      remoteVersion &&
+      localVersion &&
+      reportSkip(compareVersions(remoteVersion, localVersion), localVersion, remoteVersion)
+    ) {
       return;
     }
 
-    for (const file of SYSTEM_FILES) {
-      await copyFile(join(sourceDir, file), join(workplansDir, file));
-      console.log(`  Updated workplans/${file}`);
-    }
-
-    for (const folder of STATE_FOLDERS) {
-      const target = join(workplansDir, folder);
-      if (!existsSync(target)) {
-        await mkdir(target, { recursive: true });
-        console.log(`  Created workplans/${folder}/`);
+    try {
+      for (const file of SYSTEM_FILES) {
+        await copyFile(join(sourceDir, file), join(workplansDir, file));
+        console.log(`  Updated workplans/${file}`);
       }
-      await copyFile(
-        join(sourceDir, folder, "README.md"),
-        join(target, "README.md")
-      );
-      console.log(`  Updated workplans/${folder}/README.md`);
+
+      for (const folder of STATE_FOLDERS) {
+        const target = join(workplansDir, folder);
+        if (!existsSync(target)) {
+          await mkdir(target, { recursive: true });
+          console.log(`  Created workplans/${folder}/`);
+        }
+        await copyFile(
+          join(sourceDir, folder, "README.md"),
+          join(target, "README.md")
+        );
+        console.log(`  Updated workplans/${folder}/README.md`);
+      }
+    } catch (err) {
+      if (err.code === "EACCES" || err.code === "EPERM") {
+        throw new Error(
+          "Permission denied writing to workplans/.\n" +
+          "Check that you have write permissions here and try again."
+        );
+      }
+      throw err;
     }
 
     console.log("");
@@ -75,6 +114,7 @@ export async function runUpdate() {
       console.log("Done. User plans were not modified.");
     }
   } finally {
+    unregisterTempDir(tempDir);
     await rm(tempDir, { recursive: true, force: true });
   }
 }

--- a/cli/lib/download.mjs
+++ b/cli/lib/download.mjs
@@ -67,7 +67,10 @@ function withTimeout(promise, ms, what) {
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
-/** Downloads the init template (the directory containing workplans/) into destDir. */
+/**
+ * Downloads the init template (the directory containing workplans/) into destDir.
+ * Transient failures (offline, timeout) are retried once after a short delay.
+ */
 export async function downloadInit(destDir, { timeoutMs = DOWNLOAD_TIMEOUT_MS } = {}) {
   const local = localSource();
   if (local) {
@@ -75,15 +78,24 @@ export async function downloadInit(destDir, { timeoutMs = DOWNLOAD_TIMEOUT_MS } 
     return;
   }
   const { downloadTemplate } = await import("giget");
-  try {
-    await withTimeout(
-      downloadTemplate(REMOTE_SOURCE, { dir: destDir, force: true }),
-      timeoutMs,
-      "Template download"
-    );
-  } catch (err) {
-    throw err instanceof DownloadError ? err : classify(err);
+  const RETRIABLE = new Set(["offline", "timeout"]);
+  let lastError;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      await withTimeout(
+        downloadTemplate(REMOTE_SOURCE, { dir: destDir, force: true }),
+        timeoutMs,
+        "Template download"
+      );
+      return;
+    } catch (err) {
+      lastError = err instanceof DownloadError ? err : classify(err);
+      if (attempt === 2 || !RETRIABLE.has(lastError.kind)) throw lastError;
+      console.log("  Download failed, retrying...");
+      await new Promise((r) => setTimeout(r, 1_000));
+    }
   }
+  throw lastError;
 }
 
 /** Reads the `version:` field from a RULES.md frontmatter block (first --- block only). */

--- a/cli/lib/download.mjs
+++ b/cli/lib/download.mjs
@@ -1,0 +1,143 @@
+/**
+ * Template download with classified errors, timeout, and SIGINT cleanup.
+ *
+ * WORKPLANS_TEMPLATE_SOURCE (env) overrides the GitHub source with a local
+ * directory of the same shape as init/ (used by tests and local development).
+ */
+
+import { rmSync } from "node:fs";
+import { cp, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const REMOTE_SOURCE = "gh:agnostical/workplans/init";
+const RAW_RULES_URL =
+  "https://raw.githubusercontent.com/agnostical/workplans/main/init/workplans/RULES.md";
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+const VERSION_CHECK_TIMEOUT_MS = 10_000;
+
+export class DownloadError extends Error {
+  constructor(kind, message) {
+    super(message);
+    this.name = "DownloadError";
+    this.kind = kind;
+  }
+}
+
+function localSource() {
+  return process.env.WORKPLANS_TEMPLATE_SOURCE || null;
+}
+
+function classify(err) {
+  const msg = String((err && err.message) || err);
+  if (/(429|rate.?limit)/i.test(msg)) {
+    return new DownloadError(
+      "rate-limit",
+      "GitHub rate limit reached. Wait a few minutes and try again."
+    );
+  }
+  if (/(404|not found)/i.test(msg)) {
+    return new DownloadError(
+      "not-found",
+      "Template not found on GitHub. Check https://github.com/agnostical/workplans"
+    );
+  }
+  if (/(ENOTFOUND|ECONNREFUSED|ECONNRESET|EAI_AGAIN|ETIMEDOUT|fetch failed|network)/i.test(msg)) {
+    return new DownloadError(
+      "offline",
+      "Could not reach GitHub. Check your internet connection and try again."
+    );
+  }
+  return new DownloadError("unknown", `Download failed: ${msg}`);
+}
+
+function withTimeout(promise, ms, what) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new DownloadError(
+            "timeout",
+            `${what} timed out after ${Math.round(ms / 1000)}s. Check your connection and try again.`
+          )
+        ),
+      ms
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** Downloads the init template (the directory containing workplans/) into destDir. */
+export async function downloadInit(destDir, { timeoutMs = DOWNLOAD_TIMEOUT_MS } = {}) {
+  const local = localSource();
+  if (local) {
+    await cp(local, destDir, { recursive: true });
+    return;
+  }
+  const { downloadTemplate } = await import("giget");
+  try {
+    await withTimeout(
+      downloadTemplate(REMOTE_SOURCE, { dir: destDir, force: true }),
+      timeoutMs,
+      "Template download"
+    );
+  } catch (err) {
+    throw err instanceof DownloadError ? err : classify(err);
+  }
+}
+
+/** Reads the `version:` field from a RULES.md frontmatter block (first --- block only). */
+export function readVersionFromRules(content) {
+  const fm = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return null;
+  const line = fm[1].match(/^version:\s*(.+)$/m);
+  return line ? line[1].trim().replace(/^["']|["']$/g, "") : null;
+}
+
+/**
+ * Best-effort remote version check without downloading the full template.
+ * Returns null on any failure — callers fall back to the full download path.
+ */
+export async function fetchRemoteVersion({ timeoutMs = VERSION_CHECK_TIMEOUT_MS } = {}) {
+  try {
+    const local = localSource();
+    if (local) {
+      return readVersionFromRules(await readFile(join(local, "workplans", "RULES.md"), "utf8"));
+    }
+    const res = await withTimeout(fetch(RAW_RULES_URL), timeoutMs, "Version check");
+    if (!res.ok) return null;
+    return readVersionFromRules(await res.text());
+  } catch {
+    return null;
+  }
+}
+
+// ─── SIGINT cleanup ──────────────────────────────────────────────
+// Temp dirs registered here are removed if the user interrupts a download.
+
+const activeTempDirs = new Set();
+let sigintInstalled = false;
+
+export function registerTempDir(dir) {
+  activeTempDirs.add(dir);
+}
+
+export function unregisterTempDir(dir) {
+  activeTempDirs.delete(dir);
+}
+
+export function installSigintCleanup() {
+  if (sigintInstalled) return;
+  sigintInstalled = true;
+  process.on("SIGINT", () => {
+    for (const dir of activeTempDirs) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best effort — the OS temp cleaner will get it eventually
+      }
+    }
+    console.error("\nInterrupted. Temporary files cleaned up.");
+    process.exit(130);
+  });
+}

--- a/cli/lib/semver.mjs
+++ b/cli/lib/semver.mjs
@@ -1,0 +1,25 @@
+/**
+ * Minimal semver helpers for major.minor.patch versions.
+ * No prerelease/build support — the framework only uses plain triples.
+ */
+
+export function parseVersion(str) {
+  if (typeof str !== "string") return null;
+  const m = str.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/**
+ * Returns -1 if a < b, 0 if equal, 1 if a > b.
+ * Returns null when either version is not a valid major.minor.patch string.
+ */
+export function compareVersions(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return null;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workplans",
   "version": "0.1.1",
-  "description": "CLI for the Workplans framework — install and update markdown plan structures for AI agents.",
+  "description": "CLI for the Workplans framework \u2014 install and update markdown plan structures for AI agents.",
   "type": "module",
   "bin": {
     "workplans": "./bin/cli.mjs"
@@ -12,6 +12,7 @@
   "files": [
     "bin/",
     "commands/",
+    "lib/",
     "README.md"
   ],
   "keywords": [
@@ -33,5 +34,8 @@
   "license": "MIT",
   "dependencies": {
     "giget": "^3.1.2"
+  },
+  "scripts": {
+    "test": "node --test"
   }
 }

--- a/cli/test/cli.integration.test.mjs
+++ b/cli/test/cli.integration.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Integration tests: run the real binary via child_process against a local
+ * template fixture (WORKPLANS_TEMPLATE_SOURCE), fully offline.
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, "..", "bin", "cli.mjs");
+const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
+
+let fixtureDir;
+
+function buildFixture(version) {
+  const src = mkdtempSync(join(tmpdir(), "workplans-fixture-"));
+  const wp = join(src, "workplans");
+  mkdirSync(wp, { recursive: true });
+  writeFileSync(
+    join(wp, "RULES.md"),
+    `---\nname: workplans\nversion: ${version}\n---\n\n# Workplans: Rules\n\nFixture rules.\n`
+  );
+  writeFileSync(join(wp, "README.md"), `# Workplans\n\nFixture readme.\n`);
+  for (const folder of ["backlog", "doing", "done"]) {
+    mkdirSync(join(wp, folder), { recursive: true });
+    writeFileSync(join(wp, folder, "README.md"), `# ${folder}\n`);
+  }
+  return src;
+}
+
+function run(args, cwd, env = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, WORKPLANS_TEMPLATE_SOURCE: fixtureDir, ...env },
+  });
+}
+
+function freshDir() {
+  return mkdtempSync(join(tmpdir(), "workplans-cwd-"));
+}
+
+before(() => {
+  fixtureDir = buildFixture("0.9.0");
+});
+
+after(() => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+test("--version prints the package version with exit 0", () => {
+  const r = run(["--version"], freshDir());
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout.trim(), pkg.version);
+});
+
+test("--help shows usage and known commands with exit 0", () => {
+  const r = run(["--help"], freshDir());
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Usage:/);
+  assert.match(r.stdout, /init/);
+  assert.match(r.stdout, /update/);
+});
+
+test("unknown command exits 1 and shows help", () => {
+  const r = run(["frobnicate"], freshDir());
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Unknown command: frobnicate/);
+  assert.match(r.stderr, /Usage:/);
+});
+
+test("extra positional arguments are rejected with exit 1", () => {
+  const r = run(["update", "extra"], freshDir());
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /expects 0 argument/);
+});
+
+test("init scaffolds workplans/ in a clean directory", () => {
+  const cwd = freshDir();
+  const r = run(["init"], cwd);
+  assert.equal(r.status, 0);
+  assert.ok(existsSync(join(cwd, "workplans", "RULES.md")));
+  assert.ok(existsSync(join(cwd, "workplans", "backlog", "README.md")));
+  assert.ok(existsSync(join(cwd, "workplans", "doing")));
+  assert.ok(existsSync(join(cwd, "workplans", "done")));
+});
+
+test("init fails clearly when workplans/ already exists", () => {
+  const cwd = freshDir();
+  assert.equal(run(["init"], cwd).status, 0);
+  const r = run(["init"], cwd);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /already exists/);
+  assert.match(r.stderr, /npx workplans update/);
+});
+
+test("update fails clearly when workplans/ does not exist", () => {
+  const r = run(["update"], freshDir());
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /workplans\/ not found/);
+  assert.match(r.stderr, /npx workplans init/);
+});
+
+test("update skips the download when local version equals remote", () => {
+  const cwd = freshDir();
+  run(["init"], cwd);
+  const r = run(["update"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /already up to date \(v0\.9\.0\)/);
+  assert.doesNotMatch(r.stdout, /Downloading/);
+});
+
+test("update skips when local version is newer than remote", () => {
+  const cwd = freshDir();
+  run(["init"], cwd);
+  const rules = join(cwd, "workplans", "RULES.md");
+  writeFileSync(rules, readFileSync(rules, "utf8").replace("version: 0.9.0", "version: 9.9.9"));
+  const r = run(["update"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /is newer than remote/);
+});
+
+test("update refreshes system files and preserves user plans when remote is newer", () => {
+  const cwd = freshDir();
+  run(["init"], cwd);
+
+  // Simulate an older local install and a user plan.
+  const rules = join(cwd, "workplans", "RULES.md");
+  writeFileSync(rules, readFileSync(rules, "utf8").replace("version: 0.9.0", "version: 0.1.0"));
+  const planPath = join(cwd, "workplans", "backlog", "2601551600_user-plan.md");
+  writeFileSync(planPath, "user plan content — must survive update\n");
+  rmSync(join(cwd, "workplans", "done"), { recursive: true });
+
+  const r = run(["update"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Updated to v0\.9\.0 \(from v0\.1\.0\)/);
+  assert.match(readFileSync(rules, "utf8"), /version: 0\.9\.0/);
+  assert.equal(readFileSync(planPath, "utf8"), "user plan content — must survive update\n");
+  assert.ok(existsSync(join(cwd, "workplans", "done", "README.md")), "missing state folder is recreated");
+});

--- a/cli/test/semver.test.mjs
+++ b/cli/test/semver.test.mjs
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseVersion, compareVersions } from "../lib/semver.mjs";
+import { readVersionFromRules } from "../lib/download.mjs";
+
+test("parseVersion accepts plain and v-prefixed triples", () => {
+  assert.deepEqual(parseVersion("0.3.1"), [0, 3, 1]);
+  assert.deepEqual(parseVersion("v1.2.3"), [1, 2, 3]);
+  assert.deepEqual(parseVersion(" 0.10.0 "), [0, 10, 0]);
+});
+
+test("parseVersion rejects invalid input", () => {
+  assert.equal(parseVersion("0.3"), null);
+  assert.equal(parseVersion("0.3.1-beta"), null);
+  assert.equal(parseVersion("abc"), null);
+  assert.equal(parseVersion(""), null);
+  assert.equal(parseVersion(undefined), null);
+});
+
+test("compareVersions orders numerically, not lexicographically", () => {
+  assert.equal(compareVersions("0.10.0", "0.9.9"), 1);
+  assert.equal(compareVersions("0.9.9", "0.10.0"), -1);
+  assert.equal(compareVersions("0.3.1", "0.3.1"), 0);
+  assert.equal(compareVersions("1.0.0", "0.99.99"), 1);
+  assert.equal(compareVersions("0.3.0", "0.3.1"), -1);
+});
+
+test("compareVersions returns null on unparseable input", () => {
+  assert.equal(compareVersions("0.3", "0.3.1"), null);
+  assert.equal(compareVersions("0.3.1", "nope"), null);
+});
+
+test("readVersionFromRules reads only the frontmatter block", () => {
+  const content = `---
+name: workplans
+version: 0.3.1
+---
+
+# Rules
+
+Some body with a YAML example:
+
+\`\`\`yaml
+version: 9.9.9
+\`\`\`
+`;
+  assert.equal(readVersionFromRules(content), "0.3.1");
+});
+
+test("readVersionFromRules handles quoted values and missing fields", () => {
+  assert.equal(readVersionFromRules(`---\nversion: "0.4.0"\n---\n`), "0.4.0");
+  assert.equal(readVersionFromRules(`---\nname: workplans\n---\n`), null);
+  assert.equal(readVersionFromRules(`no frontmatter here`), null);
+});


### PR DESCRIPTION
Closes #67 and #68 (milestone [cli-v0.2.0](https://github.com/agnostical/workplans/milestone/6)). Technical foundation before the CLI grows new commands (templates #55, migrate #70, sync #71).

## Fixes (#67)

- **Real semver comparison** in `update` (`lib/semver.mjs`, no dependencies): updates only when remote > local, reports "already up to date" on equal and "local is newer" on inverted — the old `===` would have failed at 0.10.0 and downgraded on any mismatch.
- **Skip the download when there is nothing to update**: a cheap raw fetch of the remote RULES.md version gates the full template download (best effort — falls through to download on failure, with an authoritative re-check after).
- **Classified network errors** (`lib/download.mjs`): offline, rate-limit, not-found and timeout each get an actionable message instead of a raw stack trace. 30s download timeout.
- **SIGINT cleanup**: interrupting a download removes the temp directory and exits 130.
- **Permission errors** (`EACCES`/`EPERM`) produce a clear message in both commands.

## Improvements (#68)

- **Extensible command registry router** in `bin/cli.mjs`: adding a command is one registry entry plus one module — help text is generated from the registry, positional arity is validated. Ready for `add <template>`, `migrate` and `sync`.
- **Test suite with `node:test`** (zero new dependencies): 16 tests — unit (semver ordering incl. the 0.10.0 case, frontmatter-only version parsing) and integration (the real binary via child_process against a local template fixture, fully offline through the `WORKPLANS_TEMPLATE_SOURCE` override; covers init/update happy paths, error paths, version skip logic, and user-plan preservation).
- **CI**: tests run on every PR touching `cli/`; a publish workflow releases to npm on `cli-v*` GitHub releases (requires the `NPM_TOKEN` repository secret — needs to be configured once).

No behavior changes for end users beyond better messages and the skip optimization; `package.json` version stays at 0.1.1 — the bump to 0.2.0 ships with the templates release.