### PR TITLE
feat: CLI templates system — list and add commands with initial catalog

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,10 +13,16 @@ This scaffolds a `workplans/` folder in the current directory with `RULES.md`, `
 ## Commands
 
 ```bash
-npx workplans init     # Scaffold the framework (fails if workplans/ already exists)
-npx workplans update   # Refresh RULES.md and README.md, ensure state folders exist
-                       # User plans are never touched
+npx workplans init             # Scaffold the framework (fails if workplans/ already exists)
+npx workplans update           # Refresh RULES.md and README.md, ensure state folders exist
+                               # User plans are never touched
+npx workplans list             # List available plan templates
+npx workplans add <template>   # Add a template to workplans/backlog/ with a fresh id
 ```
+
+### Templates
+
+`add` copies a ready-made plan from the [template catalog](https://github.com/agnostical/workplans/tree/main/templates) into your backlog, rewriting its frontmatter: a fresh timestamp id (collision-safe), `state: "backlog"`, `backlog_date` now, and `format_version` matching your local RULES.md. Phase 1: Definition arrives unchecked on purpose — refine the plan against your real project before executing it. Adding the same template twice is refused (non-destructive). See the [catalog README](https://github.com/agnostical/workplans/tree/main/templates#contributing-a-template) to contribute new templates.
 
 ### Flags
 

--- a/cli/bin/cli.mjs
+++ b/cli/bin/cli.mjs
@@ -36,11 +36,30 @@ const registry = new Map([
         "Refresh RULES.md/README.md and ensure state folders exist (never touches user plans)",
     },
   ],
+  [
+    "list",
+    {
+      load: () => import("../commands/list.mjs"),
+      fn: "runList",
+      positionals: 0,
+      summary: "List available plan templates",
+    },
+  ],
+  [
+    "add",
+    {
+      load: () => import("../commands/add.mjs"),
+      fn: "runAdd",
+      positionals: 1,
+      usage: "add <template>",
+      summary: "Add a plan template to your backlog with a fresh id",
+    },
+  ],
 ]);
 
 function buildHelp() {
   const lines = [...registry.entries()].map(
-    ([name, cmd]) => `  ${name.padEnd(10)}${cmd.summary}`
+    ([name, cmd]) => `  ${(cmd.usage || name).padEnd(16)}${cmd.summary}`
   );
   return `workplans v${pkg.version}
 

--- a/cli/commands/add.mjs
+++ b/cli/commands/add.mjs
@@ -1,0 +1,97 @@
+import { existsSync, readdirSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fetchTemplate, readVersionFromRules } from "../lib/download.mjs";
+import { generateId, frontmatterDate } from "../lib/planid.mjs";
+
+/**
+ * Rewrites the template frontmatter for a fresh plan: new id, backlog state,
+ * creation date now, format_version from the local RULES.md. Authorship fields
+ * stay empty — the plan belongs to whoever refines it.
+ */
+function instantiate(content, { id, date, formatVersion }) {
+  const fm = content.match(/^---\n[\s\S]*?\n---/);
+  if (!fm) throw new Error("Template is malformed (missing frontmatter). Please report this issue.");
+  let block = fm[0];
+  block = block.replace(/^id:.*$/m, `id: ${id}`);
+  block = block.replace(/^state:.*$/m, `state: "backlog"`);
+  block = block.replace(/^backlog_date:.*$/m, `backlog_date: "${date}"`);
+  block = block.replace(/^doing_date:.*$/m, `doing_date: ""`);
+  block = block.replace(/^done_date:.*$/m, `done_date: ""`);
+  if (formatVersion) {
+    block = block.replace(/^format_version:.*$/m, `format_version: "${formatVersion}"`);
+  }
+  return content.replace(fm[0], block);
+}
+
+export async function runAdd(name) {
+  const workplansDir = resolve(process.cwd(), "workplans");
+  const backlogDir = join(workplansDir, "backlog");
+
+  if (!existsSync(backlogDir)) {
+    throw new Error(
+      "workplans/backlog/ not found in the current directory.\n" +
+      "Did you mean 'npx workplans init'?"
+    );
+  }
+
+  // Non-destructive: one instance of a template per backlog.
+  const existing = readdirSync(backlogDir).find((f) => f.endsWith(`_${name}.md`));
+  if (existing) {
+    throw new Error(
+      `A plan from this template already exists: workplans/backlog/${existing}\n` +
+      "Rename or complete it before adding the template again."
+    );
+  }
+
+  console.log(`Fetching template '${name}'...`);
+  const content = await fetchTemplate(name);
+  if (content === null) {
+    throw new Error(
+      `Template '${name}' not found.\n` +
+      "See available templates with 'npx workplans list'."
+    );
+  }
+
+  // Ids are seconds-precision: two adds in the same second would collide,
+  // and relations reference plans by bare id. Advance one second until free
+  // across all state folders.
+  let now = new Date();
+  let id = generateId(now);
+  const idTaken = (candidate) =>
+    ["backlog", "doing", "done"].some((folder) => {
+      const dir = join(workplansDir, folder);
+      return existsSync(dir) && readdirSync(dir).some((f) => f.startsWith(`${candidate}_`));
+    });
+  while (idTaken(id)) {
+    now = new Date(now.getTime() + 1000);
+    id = generateId(now);
+  }
+
+  const rulesPath = join(workplansDir, "RULES.md");
+  const formatVersion = existsSync(rulesPath)
+    ? readVersionFromRules(await readFile(rulesPath, "utf8"))
+    : null;
+
+  const plan = instantiate(content, { id, date: frontmatterDate(now), formatVersion });
+  const filename = `${id}_${name}.md`;
+
+  try {
+    await writeFile(join(backlogDir, filename), plan, { flag: "wx" });
+  } catch (err) {
+    if (err.code === "EACCES" || err.code === "EPERM") {
+      throw new Error(
+        "Permission denied writing to workplans/backlog/.\n" +
+        "Check that you have write permissions here and try again."
+      );
+    }
+    throw err;
+  }
+
+  console.log("");
+  console.log(`Done. Created workplans/backlog/${filename}`);
+  console.log("");
+  console.log("Next steps:");
+  console.log("  - Complete Phase 1: Definition with your agent (refine objective, phases and steps)");
+  console.log("  - Move the plan to doing/ when Phase 1 is checked");
+}

--- a/cli/commands/list.mjs
+++ b/cli/commands/list.mjs
@@ -1,0 +1,15 @@
+import { fetchTemplatesIndex } from "../lib/download.mjs";
+
+export async function runList() {
+  console.log("Available templates:\n");
+
+  const templates = await fetchTemplatesIndex();
+
+  const width = Math.max(...templates.map((t) => t.name.length)) + 2;
+  for (const t of templates) {
+    console.log(`  ${t.name.padEnd(width)}${t.description}`);
+  }
+
+  console.log("");
+  console.log("Add one to your backlog with: npx workplans add <template>");
+}

--- a/cli/lib/download.mjs
+++ b/cli/lib/download.mjs
@@ -124,6 +124,56 @@ export async function fetchRemoteVersion({ timeoutMs = VERSION_CHECK_TIMEOUT_MS 
   }
 }
 
+// ─── Templates ──────────────────────────────────────────────────
+// WORKPLANS_TEMPLATES_SOURCE (env) overrides the GitHub source with a local
+// directory shaped like templates/ (index.json + <name>.md files).
+
+const RAW_TEMPLATES_BASE =
+  "https://raw.githubusercontent.com/agnostical/workplans/main/templates";
+
+function templatesLocalSource() {
+  return process.env.WORKPLANS_TEMPLATES_SOURCE || null;
+}
+
+async function fetchRawTemplateFile(file, timeoutMs, what) {
+  const local = templatesLocalSource();
+  if (local) {
+    try {
+      return await readFile(join(local, file), "utf8");
+    } catch (err) {
+      if (err.code === "ENOENT") return null;
+      throw err;
+    }
+  }
+  let res;
+  try {
+    res = await withTimeout(fetch(`${RAW_TEMPLATES_BASE}/${file}`), timeoutMs, what);
+  } catch (err) {
+    throw err instanceof DownloadError ? err : classify(err);
+  }
+  if (res.status === 404) return null;
+  if (!res.ok) throw classify(new Error(`HTTP ${res.status}`));
+  return res.text();
+}
+
+/** Returns the template catalog: [{ name, title, description }]. */
+export async function fetchTemplatesIndex({ timeoutMs = VERSION_CHECK_TIMEOUT_MS } = {}) {
+  const raw = await fetchRawTemplateFile("index.json", timeoutMs, "Template list download");
+  if (raw === null) {
+    throw new DownloadError("not-found", "Template catalog not found. Check https://github.com/agnostical/workplans/tree/main/templates");
+  }
+  try {
+    return JSON.parse(raw).templates;
+  } catch {
+    throw new DownloadError("unknown", "Template catalog is malformed. Please report this at https://github.com/agnostical/workplans/issues");
+  }
+}
+
+/** Returns the raw markdown of one template, or null when it does not exist. */
+export async function fetchTemplate(name, { timeoutMs = VERSION_CHECK_TIMEOUT_MS } = {}) {
+  return fetchRawTemplateFile(`${name}.md`, timeoutMs, "Template download");
+}
+
 // ─── SIGINT cleanup ──────────────────────────────────────────────
 // Temp dirs registered here are removed if the user interrupts a download.
 

--- a/cli/lib/planid.mjs
+++ b/cli/lib/planid.mjs
@@ -1,0 +1,20 @@
+/**
+ * Plan id and date helpers following the framework's file naming rule:
+ * {YYDDDsssss} = 2-digit year + ordinal day (001-366) + seconds of day (00000-86399).
+ */
+
+export function generateId(date = new Date()) {
+  const yy = String(date.getFullYear() % 100).padStart(2, "0");
+  const start = new Date(date.getFullYear(), 0, 0);
+  const dayOfYear = Math.floor((date - start) / 86_400_000);
+  const ddd = String(dayOfYear).padStart(3, "0");
+  const seconds = date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
+  const sssss = String(seconds).padStart(5, "0");
+  return `${yy}${ddd}${sssss}`;
+}
+
+/** Frontmatter datetime: YYYY-MM-DDThh:mm in local time. */
+export function frontmatterDate(date = new Date()) {
+  const p = (n) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${p(date.getMonth() + 1)}-${p(date.getDate())}T${p(date.getHours())}:${p(date.getMinutes())}`;
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workplans",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "CLI for the Workplans framework \u2014 install and update markdown plan structures for AI agents.",
   "type": "module",
   "bin": {

--- a/cli/test/templates.test.mjs
+++ b/cli/test/templates.test.mjs
@@ -1,0 +1,204 @@
+/**
+ * Tests for the templates system: planid generation (unit) and the
+ * list/add commands (integration, offline via WORKPLANS_TEMPLATES_SOURCE).
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateId, frontmatterDate } from "../lib/planid.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, "..", "bin", "cli.mjs");
+
+// ─── planid unit tests ──────────────────────────────────────────
+
+test("generateId follows YYDDDsssss with padding", () => {
+  // 2026-02-03 00:01:05 → year 26, day 034, seconds 65
+  const id = generateId(new Date(2026, 1, 3, 0, 1, 5));
+  assert.equal(id, "2603400065");
+  assert.equal(id.length, 10);
+});
+
+test("generateId covers year boundaries and end of day", () => {
+  assert.equal(generateId(new Date(2026, 0, 1, 0, 0, 0)), "2600100000");
+  assert.equal(generateId(new Date(2026, 11, 31, 23, 59, 59)), "2636586399");
+});
+
+test("frontmatterDate formats local ISO minutes", () => {
+  assert.equal(frontmatterDate(new Date(2026, 6, 13, 9, 5)), "2026-07-13T09:05");
+});
+
+// ─── list / add integration ─────────────────────────────────────
+
+let initFixture;
+let templatesFixture;
+
+function buildInitFixture(version) {
+  const src = mkdtempSync(join(tmpdir(), "workplans-init-fixture-"));
+  const wp = join(src, "workplans");
+  mkdirSync(wp, { recursive: true });
+  writeFileSync(join(wp, "RULES.md"), `---\nname: workplans\nversion: ${version}\n---\n\n# Rules\n`);
+  writeFileSync(join(wp, "README.md"), `# Workplans\n`);
+  for (const folder of ["backlog", "doing", "done"]) {
+    mkdirSync(join(wp, folder), { recursive: true });
+    writeFileSync(join(wp, folder, "README.md"), `# ${folder}\n`);
+  }
+  return src;
+}
+
+function buildTemplatesFixture() {
+  const src = mkdtempSync(join(tmpdir(), "workplans-templates-fixture-"));
+  writeFileSync(
+    join(src, "index.json"),
+    JSON.stringify({
+      templates: [
+        { name: "demo-template", title: "Demo template", description: "A demo template for tests" },
+        { name: "other-template", title: "Other template", description: "A second template for id collision tests" },
+      ],
+    })
+  );
+  writeFileSync(
+    join(src, "other-template.md"),
+    `---
+id: 0000000000
+title: "Other template"
+state: "backlog"
+author: ""
+author_model: ""
+assignee: ""
+assignee_model: ""
+backlog_date: ""
+doing_date: ""
+done_date: ""
+format_version: "0.0.0"
+---
+
+# Other template
+
+## Objective
+Other objective.
+`
+  );
+  writeFileSync(
+    join(src, "demo-template.md"),
+    `---
+id: 0000000000
+title: "Demo template"
+state: "backlog"
+author: ""
+author_model: ""
+assignee: ""
+assignee_model: ""
+backlog_date: ""
+doing_date: ""
+done_date: ""
+format_version: "0.0.0"
+---
+
+# Demo template
+
+## Objective
+Demo objective.
+`
+  );
+  return src;
+}
+
+function run(args, cwd) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      WORKPLANS_TEMPLATE_SOURCE: initFixture,
+      WORKPLANS_TEMPLATES_SOURCE: templatesFixture,
+    },
+  });
+}
+
+function freshProject() {
+  const cwd = mkdtempSync(join(tmpdir(), "workplans-proj-"));
+  run(["init"], cwd);
+  return cwd;
+}
+
+before(() => {
+  initFixture = buildInitFixture("0.9.0");
+  templatesFixture = buildTemplatesFixture();
+});
+
+after(() => {
+  rmSync(initFixture, { recursive: true, force: true });
+  rmSync(templatesFixture, { recursive: true, force: true });
+});
+
+test("list prints the catalog with exit 0", () => {
+  const r = run(["list"], mkdtempSync(join(tmpdir(), "workplans-any-")));
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /demo-template/);
+  assert.match(r.stdout, /A demo template for tests/);
+  assert.match(r.stdout, /workplans add <template>/);
+});
+
+test("add fails clearly outside an initialized project", () => {
+  const r = run(["add", "demo-template"], mkdtempSync(join(tmpdir(), "workplans-empty-")));
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /workplans\/backlog\/ not found/);
+  assert.match(r.stderr, /npx workplans init/);
+});
+
+test("add fails clearly for an unknown template", () => {
+  const r = run(["add", "does-not-exist"], freshProject());
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /not found/);
+  assert.match(r.stderr, /npx workplans list/);
+});
+
+test("add requires exactly one positional argument", () => {
+  const r = run(["add"], freshProject());
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /expects 1 argument/);
+});
+
+test("add instantiates the template with fresh id, dates and local format_version", () => {
+  const cwd = freshProject();
+  const r = run(["add", "demo-template"], cwd);
+  assert.equal(r.status, 0);
+
+  const files = readdirSync(join(cwd, "workplans", "backlog")).filter((f) => f.endsWith("_demo-template.md"));
+  assert.equal(files.length, 1);
+  const [file] = files;
+  assert.match(file, /^\d{10}_demo-template\.md$/);
+
+  const content = readFileSync(join(cwd, "workplans", "backlog", file), "utf8");
+  const id = file.slice(0, 10);
+  assert.match(content, new RegExp(`^id: ${id}$`, "m"), "frontmatter id matches filename");
+  assert.match(content, /^state: "backlog"$/m);
+  assert.match(content, /^backlog_date: "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}"$/m);
+  assert.match(content, /^doing_date: ""$/m);
+  assert.match(content, /^format_version: "0\.9\.0"$/m, "format_version comes from local RULES.md");
+  assert.match(content, /# Demo template/, "body is preserved");
+});
+
+test("add is non-destructive: refuses a second instance of the same template", () => {
+  const cwd = freshProject();
+  assert.equal(run(["add", "demo-template"], cwd).status, 0);
+  const r = run(["add", "demo-template"], cwd);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /already exists/);
+});
+
+test("two adds in the same second get distinct ids", () => {
+  const cwd = freshProject();
+  assert.equal(run(["add", "demo-template"], cwd).status, 0);
+  assert.equal(run(["add", "other-template"], cwd).status, 0);
+  const ids = readdirSync(join(cwd, "workplans", "backlog"))
+    .filter((f) => /^\d{10}_/.test(f))
+    .map((f) => f.slice(0, 10));
+  assert.equal(new Set(ids).size, ids.length, `ids must be unique, got: ${ids.join(", ")}`);
+});

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,19 @@
+# Plan templates
+
+Ready-to-execute plan templates for common processes. Users add them to their backlog with:
+
+```bash
+npx workplans list             # see this catalog
+npx workplans add <template>   # copy one into workplans/backlog/ with a fresh id
+```
+
+`add` rewrites the frontmatter on the way in: new timestamp `id`, `state: "backlog"`, `backlog_date` now, and `format_version` matching the user's local RULES.md. Phase 1: Definition arrives unchecked on purpose — every template must be refined against the real project before execution (that is the entry gate).
+
+## Contributing a template
+
+1. Create `templates/<name>.md` — the kebab-case filename is the template id.
+2. The file is a complete, valid plan per [RULES.md](../init/workplans/RULES.md): five H2 sections in the 0.3+ order, mandatory Phase 1: Definition and Closing phase, no emojis. Use placeholder values in the frontmatter (`id: 0000000000`, empty dates) — the CLI rewrites them.
+3. Write the Context section as instructions for replacement: what the user should fill in during Phase 1.
+4. Steps an AI agent cannot execute (browser checks, credential configuration) carry the `[manual]` prefix.
+5. Add an entry to `index.json` with `name`, `title` (must match the plan title) and a one-line `description`.
+6. Templates are in English; users' agents translate phase names and step text per rule 27 when refining.

--- a/templates/auth-setup.md
+++ b/templates/auth-setup.md
@@ -1,0 +1,75 @@
+---
+id: 0000000000
+title: "User authentication setup"
+state: "backlog"
+author: ""
+author_model: ""
+assignee: ""
+assignee_model: ""
+backlog_date: ""
+doing_date: ""
+done_date: ""
+format_version: "0.0.0"
+---
+
+# User authentication setup
+
+## Objective
+Add user authentication to the application: users can sign up, log in, log out, and recover access, with credentials stored and transmitted securely. The provider (self-hosted, OAuth, or a managed service) is decided in Phase 2 based on the project's constraints.
+
+## Progress
+### Phase 1: Definition
+- [ ] Define objective and context
+- [ ] Define phases and steps
+- [ ] Refine with the user
+
+### Phase 2: Choose the authentication strategy
+- [ ] List the constraints: user base, budget, compliance, existing infrastructure
+- [ ] Compare candidates: managed service, OAuth providers, self-hosted
+- [ ] Decide the strategy with the user and record the rationale in Context
+
+### Phase 3: Implement the core flows
+- [ ] Implement sign up with input validation
+- [ ] Implement log in and session management
+- [ ] Implement log out and session invalidation
+- [ ] Implement password recovery or provider-equivalent flow
+
+### Phase 4: Protect the application
+- [ ] Guard protected routes and resources
+- [ ] Handle expired and invalid sessions gracefully
+- [ ] Review secure storage of secrets and tokens
+- [ ] [manual] Configure provider credentials in the deployment environment
+
+### Phase 5: Verify
+- [ ] Write tests for each flow (sign up, log in, log out, recovery)
+- [ ] Test failure paths: wrong password, expired session, duplicate account
+- [ ] [manual] Verify the full flow in a browser end-to-end
+
+### Phase 6: Closing
+- [ ] Write Closing Summary
+- [ ] Validate implementation with the user
+
+## Context
+This is a template plan: replace this section during Phase 1 with the project's real background — the framework or language in use, whether any authentication exists today, and any compliance or organizational constraints that limit the choice of provider.
+
+## Implementation
+### Phase 1: Definition
+Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.
+
+### Phase 2: Choose the authentication strategy
+Evaluate against the constraints listed: a managed service minimizes maintenance but adds a dependency and cost; OAuth delegates credentials but requires provider apps per environment; self-hosted gives control but owns the security surface. Record the decision and its rationale in Context before implementing.
+
+### Phase 3: Implement the core flows
+Follow the chosen provider's integration guide. Keep the auth layer isolated behind a single module or service so a future provider change does not spread through the codebase. Validate all input server-side regardless of provider.
+
+### Phase 4: Protect the application
+Apply the guard at the routing or middleware layer, not per-view. Session expiry must redirect to log in without losing the user's intended destination. Secrets never live in the repository — use the environment or a secret manager.
+
+### Phase 5: Verify
+Automated tests cover each flow and its failure paths. The manual browser pass verifies the integrated experience: cookies, redirects, and the recovery email or provider screens that automated tests cannot reach.
+
+### Phase 6: Closing
+Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
+
+## Closing Summary
+_To be written when the last phase is completed._

--- a/templates/ci-cd-pipeline.md
+++ b/templates/ci-cd-pipeline.md
@@ -1,0 +1,73 @@
+---
+id: 0000000000
+title: "CI/CD pipeline setup"
+state: "backlog"
+author: ""
+author_model: ""
+assignee: ""
+assignee_model: ""
+backlog_date: ""
+doing_date: ""
+done_date: ""
+format_version: "0.0.0"
+---
+
+# CI/CD pipeline setup
+
+## Objective
+Set up a continuous integration and deployment pipeline: every change is built and tested automatically, and releases reach the target environment through a repeatable, observable process instead of manual steps. The platform (GitHub Actions, GitLab CI, or other) is decided in Phase 2.
+
+## Progress
+### Phase 1: Definition
+- [ ] Define objective and context
+- [ ] Define phases and steps
+- [ ] Refine with the user
+
+### Phase 2: Design the pipeline
+- [ ] Inventory what must run on each change: build, tests, linters, type checks
+- [ ] Decide the CI platform based on where the repository lives
+- [ ] Define the deployment target and trigger (tag, branch, or manual approval)
+
+### Phase 3: Continuous integration
+- [ ] Create the CI workflow running build and tests on every push and pull request
+- [ ] Cache dependencies to keep runs fast
+- [ ] Make the main branch require passing checks before merge
+
+### Phase 4: Continuous deployment
+- [ ] Create the deployment workflow with its trigger
+- [ ] [manual] Configure deployment credentials as platform secrets
+- [ ] Add a rollback path: redeploy the previous version in one action
+
+### Phase 5: Verify
+- [ ] Open a test pull request and confirm checks run and gate the merge
+- [ ] Execute one full deployment through the pipeline
+- [ ] Execute one rollback and confirm the previous version is restored
+
+### Phase 6: Closing
+- [ ] Write Closing Summary
+- [ ] Validate implementation with the user
+
+## Context
+This is a template plan: replace this section during Phase 1 with the project's real background — the stack and build tooling, the current release process (even if manual), the target environments, and any constraints such as approval requirements or deployment windows.
+
+## Implementation
+### Phase 1: Definition
+Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.
+
+### Phase 2: Design the pipeline
+The CI platform choice usually follows the repository host. Keep the pipeline definition in the repository itself so it is versioned with the code. Deployment triggers: tags for releases with versioning discipline, branch pushes for continuous delivery, manual approval where regulation or risk requires a human gate.
+
+### Phase 3: Continuous integration
+One workflow, running on push and pull request, executing the full verification inventory from Phase 2. Fail fast: cheap checks (lint, types) before expensive ones (integration tests). Dependency caching keyed on the lockfile.
+
+### Phase 4: Continuous deployment
+Deployment credentials live as platform secrets, never in the repository. The rollback path is part of the deliverable, not an afterthought — a pipeline that can only move forward is not safe to rely on.
+
+### Phase 5: Verify
+The verification is functional, not configurational: a real pull request gated by checks, a real deployment through the pipeline, and a real rollback. If any of the three cannot be demonstrated, the phase is not complete.
+
+### Phase 6: Closing
+Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
+
+## Closing Summary
+_To be written when the last phase is completed._

--- a/templates/index.json
+++ b/templates/index.json
@@ -1,0 +1,19 @@
+{
+  "templates": [
+    {
+      "name": "auth-setup",
+      "title": "User authentication setup",
+      "description": "Provider-agnostic user authentication: sign up, log in, recovery, protected routes"
+    },
+    {
+      "name": "ci-cd-pipeline",
+      "title": "CI/CD pipeline setup",
+      "description": "Continuous integration and deployment with rollback, platform decided in-plan"
+    },
+    {
+      "name": "refactor-legacy-module",
+      "title": "Legacy module refactor",
+      "description": "Behavior-preserving refactor with characterization tests as the safety net"
+    }
+  ]
+}

--- a/templates/refactor-legacy-module.md
+++ b/templates/refactor-legacy-module.md
@@ -1,0 +1,73 @@
+---
+id: 0000000000
+title: "Legacy module refactor"
+state: "backlog"
+author: ""
+author_model: ""
+assignee: ""
+assignee_model: ""
+backlog_date: ""
+doing_date: ""
+done_date: ""
+format_version: "0.0.0"
+---
+
+# Legacy module refactor
+
+## Objective
+Refactor a legacy module to a maintainable state without changing its observable behavior: same inputs, same outputs, better internals. The safety net comes first — no restructuring happens until the current behavior is captured by tests.
+
+## Progress
+### Phase 1: Definition
+- [ ] Define objective and context
+- [ ] Define phases and steps
+- [ ] Refine with the user
+
+### Phase 2: Understand and fence the module
+- [ ] Map the module's public surface: entry points, consumers, side effects
+- [ ] Document current behavior, including the surprising parts
+- [ ] Identify the seams where the module connects to the rest of the system
+
+### Phase 3: Build the safety net
+- [ ] Write characterization tests capturing current behavior as-is
+- [ ] Cover the edge cases found in Phase 2, even the ones that look like bugs
+- [ ] Confirm the suite fails when behavior changes (mutate, observe, revert)
+
+### Phase 4: Refactor in small steps
+- [ ] Restructure incrementally, running the suite after each step
+- [ ] Keep each commit behavior-preserving and independently revertable
+- [ ] Record intentional behavior questions for the user instead of fixing silently
+
+### Phase 5: Verify and hand over
+- [ ] Full suite green, coverage of the module reported
+- [ ] Consumers of the module verified against the refactored version
+- [ ] Document the new structure where the team will find it
+
+### Phase 6: Closing
+- [ ] Write Closing Summary
+- [ ] Validate implementation with the user
+
+## Context
+This is a template plan: replace this section during Phase 1 with the module's real background — what it does, why it needs the refactor now, known trouble spots, and any behavior that consumers depend on even if undocumented.
+
+## Implementation
+### Phase 1: Definition
+Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.
+
+### Phase 2: Understand and fence the module
+Read before touching. The map of entry points and consumers defines the contract that must survive; the surprising behaviors are the most important to document because someone probably depends on them.
+
+### Phase 3: Build the safety net
+Characterization tests assert what the code does, not what it should do — bugs included. A suspected bug becomes a question for the user, never a silent fix during refactoring. Verify the net actually catches: introduce a deliberate change, watch the suite fail, revert.
+
+### Phase 4: Refactor in small steps
+Small, reversible steps with the suite as the referee. If a step cannot be expressed as a behavior-preserving change, it does not belong in this plan — record it as a follow-up. The commit history should read as a sequence of safe moves.
+
+### Phase 5: Verify and hand over
+Green suite plus verified consumers is the exit condition. The handover documentation lives where the team already looks (module docs, architecture notes), not in this plan.
+
+### Phase 6: Closing
+Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
+
+## Closing Summary
+_To be written when the last phase is completed._


### PR DESCRIPTION
Closes #55 — the last issue of milestone [cli-v0.2.0](https://github.com/agnostical/workplans/milestone/6). Built on the registry router and download infrastructure from #76.

## New features

- **`workplans list`**: prints the template catalog (name + description) from `templates/index.json` via a cheap raw fetch.
- **`workplans add <template>`**: copies a template into `workplans/backlog/` rewriting its frontmatter — fresh timestamp id, `state: "backlog"`, `backlog_date` now, and `format_version` taken from the local RULES.md so the plan matches the user's installed framework version. Non-destructive: refuses a second instance of the same template. Phase 1: Definition arrives unchecked on purpose — the entry gate forces refinement against the real project before execution.
- **Initial catalog (3 templates)**: `auth-setup`, `ci-cd-pipeline`, `refactor-legacy-module` — each a complete valid plan (English, provider-agnostic, `[manual]` prefixes where agents cannot act), living in `templates/` at the repo root with a contributing guide.

## Notable detail: collision-safe ids

End-to-end verification caught a real bug before it shipped: ids are seconds-precision, so two `add` runs in the same second produced the same id. Rule 22 tolerates it (uniqueness = timestamp + description) but bare-id references (relations, v0.4.0) would become ambiguous. `add` now advances one second until the id is free across all state folders — covered by a test.

## Verification

- 26 tests pass (10 new: planid unit tests incl. year boundaries, list/add integration against a local fixture, offline via `WORKPLANS_TEMPLATES_SOURCE`).
- Real end-to-end: `init` + the three real templates instantiated in a temp project — distinct ids, and **validate.sh passes the generated plans with 0 errors**.
- `package.json` bumped to **0.2.0**: merging this completes the milestone content; the `cli-v0.2.0` GitHub release will trigger the npm publish workflow.