### PR TITLE
feat: format 0.4.0 — tracker-ready contract, structured Closing Summary, project constants; CLI 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,13 @@ This is non-destructive — it fails with a clear error if a `workplans/` folder
 npx workplans update
 ```
 
-`update` refreshes only the framework system files. Your plans inside `backlog/`, `doing/`, and `done/` are never touched.
+`update` refreshes only the framework system files. Your plans inside `backlog/`, `doing/`, and `done/` are never touched, and neither is the root `workplans/README.md` — it is yours after init and carries the project constants. After updating across a format release, bring your plans up to the new format with:
+
+```bash
+npx workplans migrate
+```
+
+`migrate` covers `backlog/` by default (`--doing` opts in work-in-progress plans; `done/` is never migrated) and supports `--dry-run`.
 
 #### Option B: From GitHub
 Download the `.zip`, extract it, and copy the `workplans` folder (inside `init/`) into your project.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workplans
 
-![version](https://img.shields.io/github/v/release/agnostical/workplans)
+![version](https://img.shields.io/github/v/release/agnostical/workplans?filter=v*)
 
 An open framework for managing AI-driven work plans using structured Markdown files, with YAML frontmatter metadata that guides AI agents through task execution. Plans flow through a defined lifecycle:
 
@@ -107,7 +107,7 @@ npx workplans migrate
 #### Option B: From GitHub
 Download the `.zip`, extract it, and copy the `workplans` folder (inside `init/`) into your project.
 
-[![Download latest release](https://img.shields.io/github/v/release/agnostical/workplans?label=Download&style=for-the-badge&logo=github)](https://github.com/agnostical/workplans/releases/latest)
+[![Download latest release](https://img.shields.io/github/v/release/agnostical/workplans?filter=v*&label=Download&style=for-the-badge&logo=github)](https://github.com/agnostical/workplans/releases)
 
 #### Option C: Using giget directly
 If you prefer not to install the CLI, you can use `giget`:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ An open framework for managing AI-driven work plans using structured Markdown fi
 - **Unique IDs:** Each plan gets an immutable ID derived from the system clock (including ordinal day of the year + exact second of the day), preventing duplicates across teams and enabling conflict-free collaboration in shared repositories.
 - **Context-efficient structure:** Compact Markdown + YAML frontmatter keeps plans parseable and self-contained, reducing noise in the AI agent's context window.
 - **Built for collaboration:** Plans track authors, assignees, and AI models involved, keeping a clear record of who created and executed each plan.
+- **Tracker-ready:** Typed relations, priority, estimates with a declarable scale, and a sync contract (`tracked_in` + plan marker) that lets plans mirror into Linear, Jira, or GitHub without giving up the markdown as the source of truth.
+- **Extensible:** Optional extensions (like the [visual board](https://github.com/agnostical/board)) can be installed in the `extend/` folder.
 
 ## What is a plan?
 
@@ -24,17 +26,21 @@ The example below shows the required sections and field order. AI agents fill in
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "backlog"
+priority: ""
+estimate: ""
 author: ""
 author_model: ""
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "YYYY-MM-DDThh:mm"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup
@@ -164,6 +170,14 @@ Move the dashboard-redesign plan to doing
 ```
 
 The agent will create plans, move them between states, and update progress as it works. See the [RULES.md](init/workplans/RULES.md) inside the workplans folder for the complete template and rules.
+
+## Extensions
+
+Optional extensions can be installed in `workplans/extend/`. For example, the [visual board](https://github.com/agnostical/board) provides a Kanban-style dashboard:
+
+```bash
+npx giget gh:agnostical/board workplans/extend/board
+```
 
 ## License
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -43,7 +43,7 @@ npx workplans add <template>   # Add a template to workplans/backlog/ with a fre
 
 ## Versioning
 
-This CLI tool versions independently from the Workplans framework format spec. `workplans@0.1.x` is a CLI release; the framework format is versioned in [`RULES.md`](https://github.com/agnostical/workplans/blob/main/init/workplans/RULES.md) and bumped separately when the plan format changes.
+This CLI tool versions independently from the Workplans framework format spec. `workplans@0.3.x` is a CLI release; the framework format is versioned in [`RULES.md`](https://github.com/agnostical/workplans/blob/main/init/workplans/RULES.md) and bumped separately when the plan format changes.
 
 ## Links
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,7 +34,7 @@ npx workplans add <template>   # Add a template to workplans/backlog/ with a fre
 
 ### Templates
 
-`add` copies a ready-made plan from the [template catalog](https://github.com/agnostical/workplans/tree/main/templates) into your backlog, rewriting its frontmatter: a fresh timestamp id (collision-safe), `state: "backlog"`, `backlog_date` now, and `format_version` matching your local RULES.md. Phase 1: Definition arrives unchecked on purpose — refine the plan against your real project before executing it. Adding the same template twice is refused (non-destructive). See the [catalog README](https://github.com/agnostical/workplans/tree/main/templates#contributing-a-template) to contribute new templates.
+`add` copies a ready-made plan from the [template catalog](https://github.com/agnostical/workplans/tree/main/templates) into your backlog, rewriting its frontmatter: a fresh timestamp id (collision-safe), `state: "backlog"`, `backlog_date` now, and the format matching your local RULES.md (on a 0.4.0+ framework the template is migrated to the current contract as it lands). Phase 1: Definition arrives unchecked on purpose — refine the plan against your real project before executing it. Adding the same template twice is refused (non-destructive). See the [catalog README](https://github.com/agnostical/workplans/tree/main/templates#contributing-a-template) to contribute new templates.
 
 ### Flags
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,11 +14,23 @@ This scaffolds a `workplans/` folder in the current directory with `RULES.md`, `
 
 ```bash
 npx workplans init             # Scaffold the framework (fails if workplans/ already exists)
-npx workplans update           # Refresh RULES.md and README.md, ensure state folders exist
-                               # User plans are never touched
+npx workplans update           # Refresh system files (RULES.md, state-folder READMEs)
+                               # User plans and the root README are never touched
+npx workplans migrate          # Migrate backlog plans to the installed format version
 npx workplans list             # List available plan templates
 npx workplans add <template>   # Add a template to workplans/backlog/ with a fresh id
 ```
+
+### Update ownership
+
+`update` replaces system files only: `RULES.md` and the state-folder READMEs. The root `workplans/README.md` is user-owned after init — it carries the project constants (`work_on`, `tracker`, `estimate_scale`) in its frontmatter — so `update` creates it only when missing and never overwrites it. If your `RULES.md` still declares `work_on` (pre-0.4.0 layout), `update` moves it into the README frontmatter automatically before replacing `RULES.md`.
+
+### Migrate
+
+`migrate` brings plans written against an older format up to the version installed in `RULES.md`, applying the documented transition for each version pair (for 0.3.x → 0.4.0: field reorder, `format_version` → `format` rename, new empty fields, bare `relations:` key). Content sections are preserved verbatim.
+
+- Scope: `backlog/` by default; `doing/` only with `--doing`; `done/` is never migrated (historical record).
+- `--dry-run` lists what would change without writing.
 
 ### Templates
 

--- a/cli/bin/cli.mjs
+++ b/cli/bin/cli.mjs
@@ -14,6 +14,8 @@ const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8
  *   load        dynamic import of the command module
  *   fn          exported function to run
  *   positionals number of positional arguments after the command name
+ *   flags       allowed flags; when present, the matched flags are passed
+ *               to fn as a trailing Set
  *   summary     one-line description for --help
  */
 const registry = new Map([
@@ -34,6 +36,17 @@ const registry = new Map([
       positionals: 0,
       summary:
         "Refresh RULES.md/README.md and ensure state folders exist (never touches user plans)",
+    },
+  ],
+  [
+    "migrate",
+    {
+      load: () => import("../commands/migrate.mjs"),
+      fn: "runMigrate",
+      positionals: 0,
+      flags: ["--doing", "--dry-run"],
+      usage: "migrate [--doing] [--dry-run]",
+      summary: "Migrate backlog plans to the installed format (doing/ needs --doing; done/ never)",
     },
   ],
   [
@@ -98,9 +111,21 @@ async function main() {
     process.exit(1);
   }
 
-  if (rest.length !== command.positionals) {
+  const allowedFlags = new Set(command.flags || []);
+  const flagArgs = rest.filter((a) => a.startsWith("-"));
+  const positionals = rest.filter((a) => !a.startsWith("-"));
+
+  for (const flag of flagArgs) {
+    if (!allowedFlags.has(flag)) {
+      console.error(`Unknown flag for '${arg}': ${flag}\n`);
+      console.error(buildHelp());
+      process.exit(1);
+    }
+  }
+
+  if (positionals.length !== command.positionals) {
     console.error(
-      `'${arg}' expects ${command.positionals} argument(s), got ${rest.length}.\n`
+      `'${arg}' expects ${command.positionals} argument(s), got ${positionals.length}.\n`
     );
     console.error(buildHelp());
     process.exit(1);
@@ -108,7 +133,8 @@ async function main() {
 
   try {
     const mod = await command.load();
-    await mod[command.fn](...rest);
+    const args = command.flags ? [...positionals, new Set(flagArgs)] : positionals;
+    await mod[command.fn](...args);
   } catch (err) {
     console.error(`Error: ${err.message}`);
     process.exit(1);

--- a/cli/bin/cli.mjs
+++ b/cli/bin/cli.mjs
@@ -35,7 +35,7 @@ const registry = new Map([
       fn: "runUpdate",
       positionals: 0,
       summary:
-        "Refresh RULES.md/README.md and ensure state folders exist (never touches user plans)",
+        "Refresh system files and ensure state folders exist (never touches user plans or the root README)",
     },
   ],
   [

--- a/cli/commands/add.mjs
+++ b/cli/commands/add.mjs
@@ -3,6 +3,8 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fetchTemplate, readVersionFromRules } from "../lib/download.mjs";
 import { generateId, frontmatterDate } from "../lib/planid.mjs";
+import { compareVersions } from "../lib/semver.mjs";
+import { transitionTo040 } from "../lib/transitions.mjs";
 
 /**
  * Rewrites the template frontmatter for a fresh plan: new id, backlog state,
@@ -73,7 +75,17 @@ export async function runAdd(name) {
     ? readVersionFromRules(await readFile(rulesPath, "utf8"))
     : null;
 
-  const plan = instantiate(content, { id, date: frontmatterDate(now), formatVersion });
+  // On a 0.4.0+ framework, keep the template's own declared format and apply
+  // the documented transition instead of stamping a version the shape of the
+  // frontmatter would contradict.
+  const needs040 =
+    formatVersion !== null && (compareVersions(formatVersion, "0.4.0") ?? -1) >= 0;
+  let plan = instantiate(content, {
+    id,
+    date: frontmatterDate(now),
+    formatVersion: needs040 ? null : formatVersion,
+  });
+  if (needs040) plan = transitionTo040(plan);
   const filename = `${id}_${name}.md`;
 
   try {

--- a/cli/commands/migrate.mjs
+++ b/cli/commands/migrate.mjs
@@ -3,6 +3,7 @@ import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { compareVersions } from "../lib/semver.mjs";
 import { parseFrontmatter, getField } from "../lib/frontmatter.mjs";
+import { planFormat, reorderSections030, frontmatter040, validate040 } from "../lib/transitions.mjs";
 
 /**
  * `workplans migrate` — bring plans up to the installed framework version.
@@ -12,110 +13,6 @@ import { parseFrontmatter, getField } from "../lib/frontmatter.mjs";
  * byte for byte except the 0.2.x section reorder; only frontmatter and
  * section order change.
  */
-
-// 0.4.0 frontmatter contract: exact field order and empty forms.
-const FIELDS_040 = [
-  "format",
-  "id",
-  "title",
-  "priority",
-  "estimate",
-  "author",
-  "author_model",
-  "assignee",
-  "assignee_model",
-  "state",
-  "backlog_date",
-  "doing_date",
-  "done_date",
-  "tracked_in",
-  "relations",
-];
-
-const SECTION_ORDER_030 = ["Objective", "Progress", "Context", "Implementation", "Closing Summary"];
-
-const SCALES = {
-  fibonacci: ["1", "2", "3", "5", "8", "13", "21"],
-  tshirt: ["xs", "s", "m", "l", "xl"],
-};
-
-/** Declared plan format: `format` with `format_version` as read-alias. */
-function planFormat(parsed) {
-  return getField(parsed, "format") ?? getField(parsed, "format_version");
-}
-
-/** Reorders the five H2 sections to the 0.3.0 layout (Objective first). */
-function reorderSections030(body) {
-  const lines = body.split("\n");
-  const starts = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (/^## /.test(lines[i])) starts.push(i);
-  }
-  if (starts.length === 0) return body;
-
-  const preamble = lines.slice(0, starts[0]).join("\n");
-  const sections = starts.map((start, idx) => {
-    const end = idx + 1 < starts.length ? starts[idx + 1] : lines.length;
-    return { name: lines[start].replace(/^## /, "").trim(), text: lines.slice(start, end).join("\n") };
-  });
-
-  const known = SECTION_ORDER_030.filter((name) => sections.some((s) => s.name === name));
-  const ordered = [];
-  let cursor = 0;
-  for (const section of sections) {
-    if (known.includes(section.name)) {
-      ordered.push(sections.find((s) => s.name === known[cursor]));
-      cursor++;
-    } else {
-      ordered.push(section);
-    }
-  }
-  return [preamble, ...ordered.map((s) => s.text)].join("\n");
-}
-
-/**
- * Rebuilds the frontmatter in the 0.4.0 contract. Returns the new block
- * lines, or throws when the plan carries fields outside the schema.
- */
-function frontmatter040(parsed) {
-  const top = parsed.fields.filter((f) => f.indent === 0);
-  const knownSource = new Set([...FIELDS_040, "format_version"]);
-  const unknown = top.filter((f) => !knownSource.has(f.key)).map((f) => f.key);
-  if (unknown.length > 0) {
-    throw new Error(`unknown frontmatter field(s): ${unknown.join(", ")} — fix manually first`);
-  }
-
-  const raw = (key) => top.find((f) => f.key === key)?.raw ?? null;
-  const lines = ["---"];
-  for (const key of FIELDS_040) {
-    if (key === "format") {
-      lines.push(`format: "0.4.0"`);
-    } else if (key === "relations") {
-      // Nested sub-keys survive as written; the empty form is the bare key.
-      const subs = parsed.fields.filter((f) => f.indent > 0);
-      lines.push("relations:");
-      for (const sub of subs) lines.push(`  ${sub.key}: ${sub.raw}`);
-    } else {
-      lines.push(`${key}: ${raw(key) ?? '""'}`);
-    }
-  }
-  lines.push("---");
-  return lines.join("\n");
-}
-
-/** Validates the migrated frontmatter against the 0.4.0 contract. */
-function validate040(content, scale) {
-  const parsed = parseFrontmatter(content);
-  const order = parsed.fields.filter((f) => f.indent === 0).map((f) => f.key);
-  if (order.join(" ") !== FIELDS_040.join(" ")) {
-    throw new Error(`migrated frontmatter is out of order: [${order.join(", ")}]`);
-  }
-  const estimate = getField(parsed, "estimate");
-  const tokens = SCALES[scale];
-  if (estimate && tokens && !tokens.includes(estimate)) {
-    throw new Error(`estimate '${estimate}' is not in the ${scale} scale`);
-  }
-}
 
 async function migratePlan(path, currentVersion, scale, dryRun) {
   const content = await readFile(path, "utf8");

--- a/cli/commands/migrate.mjs
+++ b/cli/commands/migrate.mjs
@@ -1,0 +1,205 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { compareVersions } from "../lib/semver.mjs";
+import { parseFrontmatter, getField } from "../lib/frontmatter.mjs";
+
+/**
+ * `workplans migrate` — bring plans up to the installed framework version.
+ *
+ * Scope (per the Compatibility spec): backlog/ by default, doing/ only with
+ * --doing, done/ never (historical record). Content sections are preserved
+ * byte for byte except the 0.2.x section reorder; only frontmatter and
+ * section order change.
+ */
+
+// 0.4.0 frontmatter contract: exact field order and empty forms.
+const FIELDS_040 = [
+  "format",
+  "id",
+  "title",
+  "priority",
+  "estimate",
+  "author",
+  "author_model",
+  "assignee",
+  "assignee_model",
+  "state",
+  "backlog_date",
+  "doing_date",
+  "done_date",
+  "tracked_in",
+  "relations",
+];
+
+const SECTION_ORDER_030 = ["Objective", "Progress", "Context", "Implementation", "Closing Summary"];
+
+const SCALES = {
+  fibonacci: ["1", "2", "3", "5", "8", "13", "21"],
+  tshirt: ["xs", "s", "m", "l", "xl"],
+};
+
+/** Declared plan format: `format` with `format_version` as read-alias. */
+function planFormat(parsed) {
+  return getField(parsed, "format") ?? getField(parsed, "format_version");
+}
+
+/** Reorders the five H2 sections to the 0.3.0 layout (Objective first). */
+function reorderSections030(body) {
+  const lines = body.split("\n");
+  const starts = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) starts.push(i);
+  }
+  if (starts.length === 0) return body;
+
+  const preamble = lines.slice(0, starts[0]).join("\n");
+  const sections = starts.map((start, idx) => {
+    const end = idx + 1 < starts.length ? starts[idx + 1] : lines.length;
+    return { name: lines[start].replace(/^## /, "").trim(), text: lines.slice(start, end).join("\n") };
+  });
+
+  const known = SECTION_ORDER_030.filter((name) => sections.some((s) => s.name === name));
+  const ordered = [];
+  let cursor = 0;
+  for (const section of sections) {
+    if (known.includes(section.name)) {
+      ordered.push(sections.find((s) => s.name === known[cursor]));
+      cursor++;
+    } else {
+      ordered.push(section);
+    }
+  }
+  return [preamble, ...ordered.map((s) => s.text)].join("\n");
+}
+
+/**
+ * Rebuilds the frontmatter in the 0.4.0 contract. Returns the new block
+ * lines, or throws when the plan carries fields outside the schema.
+ */
+function frontmatter040(parsed) {
+  const top = parsed.fields.filter((f) => f.indent === 0);
+  const knownSource = new Set([...FIELDS_040, "format_version"]);
+  const unknown = top.filter((f) => !knownSource.has(f.key)).map((f) => f.key);
+  if (unknown.length > 0) {
+    throw new Error(`unknown frontmatter field(s): ${unknown.join(", ")} — fix manually first`);
+  }
+
+  const raw = (key) => top.find((f) => f.key === key)?.raw ?? null;
+  const lines = ["---"];
+  for (const key of FIELDS_040) {
+    if (key === "format") {
+      lines.push(`format: "0.4.0"`);
+    } else if (key === "relations") {
+      // Nested sub-keys survive as written; the empty form is the bare key.
+      const subs = parsed.fields.filter((f) => f.indent > 0);
+      lines.push("relations:");
+      for (const sub of subs) lines.push(`  ${sub.key}: ${sub.raw}`);
+    } else {
+      lines.push(`${key}: ${raw(key) ?? '""'}`);
+    }
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+/** Validates the migrated frontmatter against the 0.4.0 contract. */
+function validate040(content, scale) {
+  const parsed = parseFrontmatter(content);
+  const order = parsed.fields.filter((f) => f.indent === 0).map((f) => f.key);
+  if (order.join(" ") !== FIELDS_040.join(" ")) {
+    throw new Error(`migrated frontmatter is out of order: [${order.join(", ")}]`);
+  }
+  const estimate = getField(parsed, "estimate");
+  const tokens = SCALES[scale];
+  if (estimate && tokens && !tokens.includes(estimate)) {
+    throw new Error(`estimate '${estimate}' is not in the ${scale} scale`);
+  }
+}
+
+async function migratePlan(path, currentVersion, scale, dryRun) {
+  const content = await readFile(path, "utf8");
+  const parsed = parseFrontmatter(content);
+  if (!parsed) throw new Error("no frontmatter");
+
+  const from = planFormat(parsed) ?? "pre-0.2.1";
+  const cmpCurrent = compareVersions(from, currentVersion);
+  if (cmpCurrent !== null && cmpCurrent >= 0) return null;
+
+  let body = parsed.body;
+  const cmp030 = compareVersions(from, "0.3.0");
+  if (cmp030 === null || cmp030 < 0) {
+    body = reorderSections030(body);
+  }
+  const migrated = `${frontmatter040(parsed)}\n${body}`;
+  validate040(migrated, scale);
+
+  if (!dryRun) await writeFile(path, migrated);
+  return { from, to: "0.4.0" };
+}
+
+export async function runMigrate(flags = new Set()) {
+  const workplansDir = resolve(process.cwd(), "workplans");
+  if (!existsSync(workplansDir)) {
+    throw new Error(
+      "workplans/ not found in the current directory.\n" +
+      "Did you mean 'npx workplans init'?"
+    );
+  }
+
+  const rules = existsSync(join(workplansDir, "RULES.md"))
+    ? parseFrontmatter(await readFile(join(workplansDir, "RULES.md"), "utf8"))
+    : null;
+  const currentVersion = rules ? getField(rules, "version") : null;
+  if (!currentVersion) {
+    throw new Error("Could not read the framework version from workplans/RULES.md.");
+  }
+  if (compareVersions(currentVersion, "0.4.0") < 0) {
+    throw new Error(
+      `Installed framework is v${currentVersion}; migrate targets 0.4.0+.\n` +
+      "Run 'npx workplans update' first."
+    );
+  }
+
+  const readmePath = join(workplansDir, "README.md");
+  const readme = existsSync(readmePath)
+    ? parseFrontmatter(await readFile(readmePath, "utf8"))
+    : null;
+  const scale = (readme && getField(readme, "estimate_scale")) || "fibonacci";
+
+  const dryRun = flags.has("--dry-run");
+  const folders = ["backlog", ...(flags.has("--doing") ? ["doing"] : [])];
+
+  console.log(`Migrating plans to format ${currentVersion}${dryRun ? " (dry run)" : ""}...`);
+  console.log(`  Scope: ${folders.join(", ")} (done/ is never migrated)`);
+
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const folder of folders) {
+    const dir = join(workplansDir, folder);
+    if (!existsSync(dir)) continue;
+    const files = (await readdir(dir)).filter((f) => f.endsWith(".md") && f !== "README.md").sort();
+    for (const file of files) {
+      const rel = `${folder}/${file}`;
+      try {
+        const result = await migratePlan(join(dir, file), currentVersion, scale, dryRun);
+        if (result === null) {
+          skipped++;
+        } else {
+          migrated++;
+          console.log(`  ${dryRun ? "Would migrate" : "Migrated"} ${rel}: ${result.from} -> ${result.to}`);
+        }
+      } catch (err) {
+        failed++;
+        console.error(`  Skipped ${rel}: ${err.message}`);
+      }
+    }
+  }
+
+  console.log("");
+  const verb = dryRun ? "would be migrated" : "migrated";
+  console.log(`${migrated} plan(s) ${verb}, ${skipped} already current${failed ? `, ${failed} failed` : ""}.`);
+  if (failed > 0) process.exitCode = 1;
+}

--- a/cli/commands/update.mjs
+++ b/cli/commands/update.mjs
@@ -1,8 +1,9 @@
 import { existsSync } from "node:fs";
-import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { compareVersions } from "../lib/semver.mjs";
+import { parseFrontmatter, getField, upsertReadmeWorkOn } from "../lib/frontmatter.mjs";
 import {
   downloadInit,
   fetchRemoteVersion,
@@ -11,8 +12,33 @@ import {
   unregisterTempDir,
 } from "../lib/download.mjs";
 
-const SYSTEM_FILES = ["RULES.md", "README.md"];
+// The root README is user-owned after init and is never overwritten here;
+// update creates it from the template only when missing (#69).
+const SYSTEM_FILES = ["RULES.md"];
 const STATE_FOLDERS = ["backlog", "doing", "done"];
+
+/**
+ * One-time migration (#69): `work_on` used to live in the RULES.md
+ * frontmatter, which update replaces. Move it to the root README
+ * frontmatter — its home since 0.4.0 — before RULES.md is overwritten.
+ * The default "." is not migrated: absent means "this same repo".
+ */
+async function migrateWorkOn(workplansDir) {
+  const rulesPath = join(workplansDir, "RULES.md");
+  if (!existsSync(rulesPath)) return;
+  const parsed = parseFrontmatter(await readFile(rulesPath, "utf8"));
+  if (!parsed) return;
+  const workOn = getField(parsed, "work_on");
+  if (!workOn || workOn === ".") return;
+
+  const readmePath = join(workplansDir, "README.md");
+  const readme = existsSync(readmePath) ? await readFile(readmePath, "utf8") : "";
+  const updated = upsertReadmeWorkOn(readme, workOn);
+  if (updated !== null) {
+    await writeFile(readmePath, updated);
+    console.log(`  Moved work_on to workplans/README.md frontmatter (${workOn})`);
+  }
+}
 
 async function readLocalVersion(rulesPath) {
   if (!existsSync(rulesPath)) return null;
@@ -78,9 +104,16 @@ export async function runUpdate() {
     }
 
     try {
+      await migrateWorkOn(workplansDir);
+
       for (const file of SYSTEM_FILES) {
         await copyFile(join(sourceDir, file), join(workplansDir, file));
         console.log(`  Updated workplans/${file}`);
+      }
+
+      if (!existsSync(join(workplansDir, "README.md"))) {
+        await copyFile(join(sourceDir, "README.md"), join(workplansDir, "README.md"));
+        console.log("  Created workplans/README.md");
       }
 
       for (const folder of STATE_FOLDERS) {

--- a/cli/lib/frontmatter.mjs
+++ b/cli/lib/frontmatter.mjs
@@ -1,0 +1,56 @@
+/**
+ * Minimal frontmatter helpers for plan and README files.
+ *
+ * Parsing is line-based and preserves raw values (quotes included) so a
+ * rewrite is byte-faithful for everything the caller does not change.
+ */
+
+/**
+ * Parses the leading frontmatter block. Returns null when the file does not
+ * start with `---`.
+ *
+ *   fields   [{ key, raw, indent }] in file order; `raw` is everything after
+ *            "key:" (trimmed), "" for a bare key; `indent` > 0 for sub-keys
+ *   body     everything after the closing `---` (leading newline preserved)
+ */
+export function parseFrontmatter(content) {
+  const lines = content.split("\n");
+  if (lines[0] !== "---") return null;
+  const fields = [];
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") {
+      end = i;
+      break;
+    }
+    const m = lines[i].match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+    if (m) {
+      fields.push({ key: m[2], raw: m[3].trim(), indent: m[1].length });
+    }
+  }
+  if (end === -1) return null;
+  return { fields, body: lines.slice(end + 1).join("\n") };
+}
+
+/** Value of a top-level field with surrounding quotes stripped, or null. */
+export function getField(parsed, key) {
+  const f = parsed.fields.find((f) => f.indent === 0 && f.key === key);
+  if (!f) return null;
+  return f.raw.replace(/^["']|["']$/g, "");
+}
+
+/**
+ * Ensures `work_on` is declared in a README's frontmatter, creating the
+ * block when the file has none. Existing declarations are left untouched.
+ * Returns the updated content, or null when nothing changed.
+ */
+export function upsertReadmeWorkOn(content, workOn) {
+  const parsed = parseFrontmatter(content);
+  if (!parsed) {
+    return `---\nwork_on: "${workOn}"\n---\n\n${content}`;
+  }
+  if (getField(parsed, "work_on") !== null) return null;
+  const lines = content.split("\n");
+  lines.splice(1, 0, `work_on: "${workOn}"`);
+  return lines.join("\n");
+}

--- a/cli/lib/transitions.mjs
+++ b/cli/lib/transitions.mjs
@@ -1,0 +1,133 @@
+/**
+ * Per-version format transitions (the Compatibility section's transition
+ * table). Pure content-in/content-out helpers shared by `migrate` and `add`.
+ */
+
+import { compareVersions } from "./semver.mjs";
+import { parseFrontmatter, getField } from "./frontmatter.mjs";
+
+// 0.4.0 frontmatter contract: exact field order and empty forms.
+export const FIELDS_040 = [
+  "format",
+  "id",
+  "title",
+  "priority",
+  "estimate",
+  "author",
+  "author_model",
+  "assignee",
+  "assignee_model",
+  "state",
+  "backlog_date",
+  "doing_date",
+  "done_date",
+  "tracked_in",
+  "relations",
+];
+
+export const SCALES = {
+  fibonacci: ["1", "2", "3", "5", "8", "13", "21"],
+  tshirt: ["xs", "s", "m", "l", "xl"],
+};
+
+const SECTION_ORDER_030 = ["Objective", "Progress", "Context", "Implementation", "Closing Summary"];
+
+/** Declared plan format: `format` with `format_version` as read-alias. */
+export function planFormat(parsed) {
+  return getField(parsed, "format") ?? getField(parsed, "format_version");
+}
+
+/** Reorders the five H2 sections to the 0.3.0 layout (Objective first). */
+export function reorderSections030(body) {
+  const lines = body.split("\n");
+  const starts = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) starts.push(i);
+  }
+  if (starts.length === 0) return body;
+
+  const preamble = lines.slice(0, starts[0]).join("\n");
+  const sections = starts.map((start, idx) => {
+    const end = idx + 1 < starts.length ? starts[idx + 1] : lines.length;
+    return { name: lines[start].replace(/^## /, "").trim(), text: lines.slice(start, end).join("\n") };
+  });
+
+  const known = SECTION_ORDER_030.filter((name) => sections.some((s) => s.name === name));
+  const ordered = [];
+  let cursor = 0;
+  for (const section of sections) {
+    if (known.includes(section.name)) {
+      ordered.push(sections.find((s) => s.name === known[cursor]));
+      cursor++;
+    } else {
+      ordered.push(section);
+    }
+  }
+  return [preamble, ...ordered.map((s) => s.text)].join("\n");
+}
+
+/**
+ * Rebuilds the frontmatter in the 0.4.0 contract. Throws when the plan
+ * carries fields outside the schema (fix those manually first).
+ */
+export function frontmatter040(parsed) {
+  const top = parsed.fields.filter((f) => f.indent === 0);
+  const knownSource = new Set([...FIELDS_040, "format_version"]);
+  const unknown = top.filter((f) => !knownSource.has(f.key)).map((f) => f.key);
+  if (unknown.length > 0) {
+    throw new Error(`unknown frontmatter field(s): ${unknown.join(", ")} — fix manually first`);
+  }
+
+  const raw = (key) => top.find((f) => f.key === key)?.raw ?? null;
+  const lines = ["---"];
+  for (const key of FIELDS_040) {
+    if (key === "format") {
+      lines.push(`format: "0.4.0"`);
+    } else if (key === "relations") {
+      // Nested sub-keys survive as written; the empty form is the bare key.
+      const subs = parsed.fields.filter((f) => f.indent > 0);
+      lines.push("relations:");
+      for (const sub of subs) lines.push(`  ${sub.key}: ${sub.raw}`);
+    } else {
+      lines.push(`${key}: ${raw(key) ?? '""'}`);
+    }
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+/** Validates a plan's frontmatter against the 0.4.0 contract. Throws on violation. */
+export function validate040(content, scale) {
+  const parsed = parseFrontmatter(content);
+  const order = parsed.fields.filter((f) => f.indent === 0).map((f) => f.key);
+  if (order.join(" ") !== FIELDS_040.join(" ")) {
+    throw new Error(`migrated frontmatter is out of order: [${order.join(", ")}]`);
+  }
+  const estimate = getField(parsed, "estimate");
+  const tokens = SCALES[scale];
+  if (estimate && tokens && !tokens.includes(estimate)) {
+    throw new Error(`estimate '${estimate}' is not in the ${scale} scale`);
+  }
+}
+
+/**
+ * Applies the documented transitions to bring a plan to 0.4.0. Returns the
+ * content unchanged when the plan already declares 0.4.0 or newer.
+ */
+export function transitionTo040(content, scale = "fibonacci") {
+  const parsed = parseFrontmatter(content);
+  if (!parsed) throw new Error("no frontmatter");
+
+  const from = planFormat(parsed);
+  const cmp = from === null ? null : compareVersions(from, "0.4.0");
+  if (cmp !== null && cmp >= 0) return content;
+
+  let body = parsed.body;
+  const cmp030 = from === null ? null : compareVersions(from, "0.3.0");
+  if (cmp030 === null || cmp030 < 0) {
+    body = reorderSections030(body);
+  }
+  const migrated = `${frontmatter040(parsed)}\n${body}`;
+  validate040(migrated, scale);
+  return migrated;
+}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workplans",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workplans",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "giget": "^3.1.2"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workplans",
-  "version": "0.2.0",
-  "description": "CLI for the Workplans framework \u2014 install and update markdown plan structures for AI agents.",
+  "version": "0.3.0",
+  "description": "CLI for the Workplans framework — install and update markdown plan structures for AI agents.",
   "type": "module",
   "bin": {
     "workplans": "./bin/cli.mjs"

--- a/cli/test/migrate.test.mjs
+++ b/cli/test/migrate.test.mjs
@@ -1,0 +1,276 @@
+/**
+ * Integration tests for `workplans migrate` and the update ownership fix
+ * (#69, #70): README preservation, work_on migration, per-version plan
+ * transitions, scope flags, and dry-run.
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, "..", "bin", "cli.mjs");
+
+let fixtureDir;
+
+function buildFixture(version) {
+  const src = mkdtempSync(join(tmpdir(), "workplans-fixture-"));
+  const wp = join(src, "workplans");
+  mkdirSync(wp, { recursive: true });
+  writeFileSync(
+    join(wp, "RULES.md"),
+    `---\nname: workplans\nversion: ${version}\n---\n\n# Workplans: Rules\n\nFixture rules.\n`
+  );
+  writeFileSync(join(wp, "README.md"), `# Workplans\n\nTemplate readme.\n`);
+  for (const folder of ["backlog", "doing", "done"]) {
+    mkdirSync(join(wp, folder), { recursive: true });
+    writeFileSync(join(wp, folder, "README.md"), `# ${folder}\n`);
+  }
+  return src;
+}
+
+function run(args, cwd) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, WORKPLANS_TEMPLATE_SOURCE: fixtureDir },
+  });
+}
+
+const PLAN_BODY_030 = `
+# Sample plan
+
+## Objective
+Do the thing.
+
+## Progress
+### Phase 1: Definition
+- [x] Define objective and context
+- [x] Define phases and steps
+- [x] Refine with the user
+
+### Phase 2: Closing
+- [ ] Write Closing Summary
+- [ ] Validate implementation with the user
+
+## Context
+Some context with accents: definición, ejecución.
+
+## Implementation
+### Phase 1: Definition
+Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.
+
+### Phase 2: Closing
+Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
+
+## Closing Summary
+_To be written when the last phase is completed._
+`;
+
+function plan030(id, state) {
+  return `---
+id: ${id}
+title: "Sample plan"
+state: "${state}"
+author: "Alice"
+author_model: "claude-opus-4-6"
+assignee: ""
+assignee_model: ""
+backlog_date: "2026-03-05T09:30"
+doing_date: ""
+done_date: ""
+format_version: "0.3.0"
+---${PLAN_BODY_030}`;
+}
+
+/** A 0.2.x plan: Progress above Objective, older format_version. */
+function plan020(id, state) {
+  return `---
+id: ${id}
+title: "Sample plan"
+state: "${state}"
+author: "Alice"
+author_model: "claude-opus-4-6"
+assignee: ""
+assignee_model: ""
+backlog_date: "2026-03-05T09:30"
+doing_date: ""
+done_date: ""
+format_version: "0.2.1"
+---
+
+# Sample plan
+
+## Progress
+### Phase 1: Definition
+- [x] Define objective and context
+- [x] Define phases and steps
+- [x] Refine with the user
+
+## Objective
+Do the thing.
+
+## Context
+Some context.
+
+## Implementation
+### Phase 1: Definition
+Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.
+
+## Closing Summary
+_To be written when the last phase is completed._
+`;
+}
+
+/** Scaffolds a 0.4.0 install with one 0.3.0 plan per state folder. */
+function scaffold() {
+  const cwd = mkdtempSync(join(tmpdir(), "workplans-migrate-"));
+  const wp = join(cwd, "workplans");
+  for (const folder of ["backlog", "doing", "done"]) {
+    mkdirSync(join(wp, folder), { recursive: true });
+    writeFileSync(join(wp, folder, "README.md"), `# ${folder}\n`);
+  }
+  writeFileSync(join(wp, "RULES.md"), `---\nname: workplans\nversion: 0.4.0\n---\n\n# Rules\n`);
+  writeFileSync(join(wp, "README.md"), `# My project\n`);
+  writeFileSync(join(wp, "backlog", "2601000001_sample-plan.md"), plan030("2601000001", "backlog"));
+  writeFileSync(join(wp, "doing", "2601000002_sample-plan.md"), plan030("2601000002", "doing"));
+  writeFileSync(join(wp, "done", "2601000003_sample-plan.md"), plan030("2601000003", "done"));
+  return cwd;
+}
+
+before(() => {
+  fixtureDir = buildFixture("9.9.9");
+});
+
+after(() => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+// ─── migrate ──────────────────────────────────────────────────────
+
+test("migrate rewrites a 0.3.0 backlog plan to the 0.4.0 contract, body untouched", () => {
+  const cwd = scaffold();
+  const r = run(["migrate"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Migrated backlog\/2601000001_sample-plan\.md: 0\.3\.0 -> 0\.4\.0/);
+
+  const out = readFileSync(join(cwd, "workplans", "backlog", "2601000001_sample-plan.md"), "utf8");
+  const fm = out.split("---")[1];
+  const keys = fm.trim().split("\n").map((l) => l.split(":")[0]);
+  assert.deepEqual(keys, [
+    "format", "id", "title", "priority", "estimate", "author", "author_model",
+    "assignee", "assignee_model", "state", "backlog_date", "doing_date",
+    "done_date", "tracked_in", "relations",
+  ]);
+  assert.match(fm, /format: "0\.4\.0"/);
+  assert.match(fm, /priority: ""/);
+  assert.match(fm, /tracked_in: ""/);
+  assert.match(fm, /relations:\n$/);
+  assert.ok(!fm.includes("format_version"), "format_version renamed");
+  assert.ok(out.endsWith(PLAN_BODY_030), "content sections preserved byte for byte");
+});
+
+test("migrate reorders 0.2.x sections to Objective-first", () => {
+  const cwd = scaffold();
+  writeFileSync(
+    join(cwd, "workplans", "backlog", "2601000009_old-plan.md"),
+    plan020("2601000009", "backlog")
+  );
+  const r = run(["migrate"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /2601000009_old-plan\.md: 0\.2\.1 -> 0\.4\.0/);
+  const out = readFileSync(join(cwd, "workplans", "backlog", "2601000009_old-plan.md"), "utf8");
+  assert.ok(out.indexOf("## Objective") < out.indexOf("## Progress"), "Objective moved above Progress");
+  assert.match(out, /- \[x\] Define objective and context/);
+});
+
+test("migrate touches doing/ only with --doing and never done/", () => {
+  const cwd = scaffold();
+  const doingPath = join(cwd, "workplans", "doing", "2601000002_sample-plan.md");
+  const donePath = join(cwd, "workplans", "done", "2601000003_sample-plan.md");
+  const doneBefore = readFileSync(donePath, "utf8");
+
+  let r = run(["migrate"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(readFileSync(doingPath, "utf8"), /format_version: "0\.3\.0"/, "doing untouched by default");
+
+  r = run(["migrate", "--doing"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(readFileSync(doingPath, "utf8"), /format: "0\.4\.0"/, "doing migrated with --doing");
+  assert.equal(readFileSync(donePath, "utf8"), doneBefore, "done/ is never migrated");
+});
+
+test("migrate --dry-run reports without writing", () => {
+  const cwd = scaffold();
+  const planPath = join(cwd, "workplans", "backlog", "2601000001_sample-plan.md");
+  const before = readFileSync(planPath, "utf8");
+  const r = run(["migrate", "--dry-run"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Would migrate backlog\/2601000001_sample-plan\.md/);
+  assert.equal(readFileSync(planPath, "utf8"), before);
+});
+
+test("migrate skips plans already on the current format", () => {
+  const cwd = scaffold();
+  run(["migrate"], cwd);
+  const r = run(["migrate"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /0 plan\(s\) migrated, 1 already current/);
+});
+
+test("migrate rejects unknown flags", () => {
+  const r = run(["migrate", "--all"], scaffold());
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Unknown flag for 'migrate': --all/);
+});
+
+test("migrate fails clearly when the installed framework predates 0.4.0", () => {
+  const cwd = scaffold();
+  writeFileSync(
+    join(cwd, "workplans", "RULES.md"),
+    `---\nname: workplans\nversion: 0.3.1\n---\n\n# Rules\n`
+  );
+  const r = run(["migrate"], cwd);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /migrate targets 0\.4\.0\+/);
+});
+
+// ─── update ownership (#69) ──────────────────────────────────────
+
+test("update preserves a customized root README and refreshes RULES.md", () => {
+  const cwd = scaffold();
+  const wp = join(cwd, "workplans");
+  writeFileSync(join(wp, "README.md"), `---\ntracker: "https://linear.app/acme/team/ENG"\n---\n\n# Custom\n`);
+  const r = run(["update"], cwd);
+  assert.equal(r.status, 0);
+  assert.match(readFileSync(join(wp, "README.md"), "utf8"), /Custom/, "root README untouched");
+  assert.match(readFileSync(join(wp, "RULES.md"), "utf8"), /version: 9\.9\.9/, "RULES.md replaced");
+});
+
+test("update migrates work_on from RULES.md to the README frontmatter", () => {
+  const cwd = scaffold();
+  const wp = join(cwd, "workplans");
+  writeFileSync(
+    join(wp, "RULES.md"),
+    `---\nname: workplans\nversion: 0.4.0\nwork_on: "https://github.com/acme/backend"\n---\n\n# Rules\n`
+  );
+  const r = run(["update"], cwd);
+  assert.equal(r.status, 0);
+  const readme = readFileSync(join(wp, "README.md"), "utf8");
+  assert.match(readme, /^---\nwork_on: "https:\/\/github\.com\/acme\/backend"\n---\n/);
+  assert.match(readme, /# My project/, "existing README content preserved");
+});
+
+test("update creates the root README only when missing", () => {
+  const cwd = scaffold();
+  const wp = join(cwd, "workplans");
+  rmSync(join(wp, "README.md"));
+  const r = run(["update"], cwd);
+  assert.equal(r.status, 0);
+  assert.ok(existsSync(join(wp, "README.md")));
+  assert.match(readFileSync(join(wp, "README.md"), "utf8"), /Template readme/);
+});

--- a/cli/test/templates.test.mjs
+++ b/cli/test/templates.test.mjs
@@ -165,7 +165,7 @@ test("add requires exactly one positional argument", () => {
   assert.match(r.stderr, /expects 1 argument/);
 });
 
-test("add instantiates the template with fresh id, dates and local format_version", () => {
+test("add instantiates the template with fresh id, dates and the 0.4.0 contract", () => {
   const cwd = freshProject();
   const r = run(["add", "demo-template"], cwd);
   assert.equal(r.status, 0);
@@ -181,7 +181,13 @@ test("add instantiates the template with fresh id, dates and local format_versio
   assert.match(content, /^state: "backlog"$/m);
   assert.match(content, /^backlog_date: "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}"$/m);
   assert.match(content, /^doing_date: ""$/m);
-  assert.match(content, /^format_version: "0\.9\.0"$/m, "format_version comes from local RULES.md");
+  // The local framework is 0.4.0+, so the template lands migrated to the
+  // 0.4.0 contract instead of stamping a version its shape would contradict.
+  assert.match(content, /^format: "0\.4\.0"$/m);
+  assert.match(content, /^priority: ""$/m);
+  assert.match(content, /^tracked_in: ""$/m);
+  assert.match(content, /^relations:$/m);
+  assert.ok(!/^format_version:/m.test(content), "format_version renamed to format");
   assert.match(content, /# Demo template/, "body is preserved");
 });
 

--- a/demo/workplans/RULES.md
+++ b/demo/workplans/RULES.md
@@ -156,7 +156,7 @@ References are id-pure — the immutable `id` only, never titles or slugs; tooli
 
 `tracked_in` links a plan to its mirror artifact in an external tracker — issue, task, card, epic: the URL is self-describing (e.g. `"https://linear.app/acme/issue/ENG-135"`). Written by sync tooling on local runs; `""` means not tracked. Multiple trackers: comma-separated URLs, **one mirror per tracker** — two mirrors in the same tracker signals the plan should be split, not a supported case.
 
-The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias `workplan:<id>`; new mirrors write `plan:<id>` only). The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
+The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker. Write canonical, read liberal: the marker is written as the description's last line, and readers accept it on any line. The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
 
 Source-of-truth split: the markdown owns plan content, state, and dates; the tracker owns its visual organization (projects, milestones, tracker-side assignment), which sync never overwrites. A child plan's epic/project derives from the `tracked_in` of its `parent` target. Rule 18 is unchanged: `tracked_in` covers only the plan-level mirror; inline issue links stay in prose.
 
@@ -204,6 +204,8 @@ Every plan must start with **Phase 1: Definition** (entry gate) and end with a *
 - [ ] Validate implementation with the user
 ```
 
+`Phase N` stands for the plan's actual last phase number — never the literal letter `N`.
+
 The same template applied in Spanish (`Closing Summary` stays in English inside step text because it references the exact H2 section name, which is always English):
 
 ```markdown
@@ -217,7 +219,7 @@ The same template applied in Spanish (`Closing Summary` stays in English inside 
 - [ ] Validar implementación con el usuario
 ```
 
-A plan in `backlog/` with Phase 1 unchecked is still being defined. A plan cannot move to `doing/` until all three steps are checked. A plan cannot move to `done/` until both Closing steps are checked and the user has explicitly approved.
+A plan in `backlog/` with Phase 1 unchecked is still being defined. When the agent defines the objective, context, and phases at creation, it checks the first two Definition steps; `Refine with the user` is checked only after the user validates. A plan cannot move to `doing/` until all three steps are checked. A plan cannot move to `done/` until both Closing steps are checked and the user has explicitly approved.
 
 The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions that also translate to the user's language. English canonical: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` The same entries in Spanish: `Define el Objective, el Context y las fases subsiguientes. Una vez completas, el plan queda listo para ejecución.` and `Valida la implementación con el usuario y escribe el Closing Summary. Una vez completa, el plan queda listo para moverse a done.` Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
 
@@ -233,7 +235,7 @@ The Closing Summary opens with a mandatory **leader paragraph** — the literal 
 6. 3-6 sentences, hard cap.
 7. Litmus test: it must read correctly on a release page with zero context.
 
-After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
+The paragraph and all prose follow the user's language; only the labels below are always English. After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
 
 | Label | Content |
 |-------|---------|

--- a/demo/workplans/RULES.md
+++ b/demo/workplans/RULES.md
@@ -233,9 +233,10 @@ The Closing Summary opens with a mandatory **leader paragraph** — the literal 
 4. No temporal deictics ("today", "this week").
 5. No links — pointers live in `References`.
 6. 3-6 sentences, hard cap.
-7. Litmus test: it must read correctly on a release page with zero context.
+7. In the user's language, like all plan prose — only the subsection labels are English.
+8. Litmus test: it must read correctly, in the user's language, on a release page with zero context.
 
-The paragraph and all prose follow the user's language; only the labels below are always English. After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
+After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
 
 | Label | Content |
 |-------|---------|

--- a/demo/workplans/RULES.md
+++ b/demo/workplans/RULES.md
@@ -1,7 +1,6 @@
 ---
 name: workplans
-version: 0.3.1
-work_on: "."
+version: 0.4.0
 ---
 
 # Workplans: Rules
@@ -35,7 +34,7 @@ State transitions move the file and update frontmatter; they never rename. The f
 
 The branch a plan is committed on is an explicit decision, not a side-effect of the current shell state. Resolve in order, stop at the first match. The VCS check (step 2) only fires when no policy is declared — a declared policy implies a VCS is present, so no further verification is needed:
 
-1. **Policy declared** in the agent file (AGENTS.md, CLAUDE.md, etc.) → follow it.
+1. **Policy declared** in the agent file (AGENTS.md, CLAUDE.md, etc.) → follow it. A planning-only repo may declare a main-only policy ("all plans commit directly to main") so plans never fragment across branches.
 2. **No VCS detected** (`git rev-parse --is-inside-work-tree` does not return `true`) → write the plan to disk, no branch question.
 3. **VCS + current branch is not the main branch** → commit on the current branch.
 4. **VCS + current branch is main** → ask the user whether to create a new branch first or commit on main.
@@ -46,17 +45,21 @@ This rule applies to the plan file itself. Execution changes follow their own br
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "backlog"
+priority: ""
+estimate: ""
 author: ""
 author_model: ""
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "YYYY-MM-DDThh:mm"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup
@@ -99,28 +102,70 @@ The template is in English as reference only. The `Phase N:` prefix and the five
 
 ### Frontmatter
 
-Frontmatter starts on line 1, no leading blank lines. All fields present; `""` if not applicable.
+Frontmatter starts on line 1, no leading blank lines. All fields present, in the order below; scalar fields empty to `""`.
 
 | Field | Description |
 |-------|-------------|
-| `id` | Timestamp ID matching the filename (`YYDDDsssss`). First field, immutable |
+| `format` | The schema discriminator, hence first. At creation, equals `version` in RULES.md. Read-alias: `format_version` (pre-0.4.0 name) |
+| `id` | Timestamp ID matching the filename (`YYDDDsssss`). Immutable |
 | `title` | Short descriptive title |
-| `state` | Must match the folder: `backlog`, `doing`, `done` |
+| `priority` | Urgency signal; mutable. See Triage |
+| `estimate` | Complexity in the project's declared scale; immutable in `doing/`. See Triage |
 | `author` | Human creator. Immutable. Comma-separated if multiple (e.g. `"Alice,Bob"`) |
 | `author_model` | AI model ID(s) that created the plan. See AI model attribution |
 | `assignee` | Person implementing |
 | `assignee_model` | AI model ID(s) that executed the plan |
+| `state` | Must match the folder: `backlog`, `doing`, `done` |
 | `backlog_date` | Datetime created (`YYYY-MM-DDThh:mm`) |
 | `doing_date` | Datetime work started |
 | `done_date` | Datetime completed |
-| `format_version` | Format the plan currently follows. At creation, equals `version` in RULES.md. Mutable only on explicit migration |
+| `tracked_in` | Mirror URL(s) in external tracker(s); `""` = not tracked. See Tracker sync |
+| `relations` | Typed relations to other plans; bare key when empty. See Relations |
+
+### Relations
+
+`relations` is a nested map: keys are relation types, values are comma-separated plan `id`s.
+
+```yaml
+relations:
+  blocked_by: "2606455842,2606123456"
+  relates_to: "2606123456"
+```
+
+| Type | Meaning |
+|------|---------|
+| `blocked_by` | Hard dependency: every referenced plan must be `done` before this plan moves to `doing`. Cycles are invalid |
+| `relates_to` | Soft, non-blocking association |
+| `supersedes` | This plan replaces the referenced plan(s) |
+| `parent` | Hierarchy: the `id` of the parent/epic plan |
+
+References are id-pure — the immutable `id` only, never titles or slugs; tooling resolves ids to titles at display time. Only the types in use appear as sub-keys; the empty form is the bare key `relations:` with no value. Inverses (`blocks`, `superseded_by`, `children`) are derived, never stored — each edge is written on the actionable side only. `relations` is the only nested field: nesting is reserved for open-ended membership, all other fields stay flat scalars.
+
+### Triage
+
+**`estimate`** — complexity in the scale declared by the project's `estimate_scale` constant (see Project constants); the value must belong to the scale's token set. Set or confirmed when Phase 1: Definition completes (`""` before that); immutable once the plan is in `doing/`. A top-band value signals the plan should be split before execution. Comparability is intra-project. Presets:
+
+| Scale | Tokens | Split signal (top band) |
+|-------|--------|-------------------------|
+| `fibonacci` (default) | 1, 2, 3, 5, 8, 13, 21 | 13, 21 |
+| `tshirt` | xs, s, m, l, xl | xl |
+
+**`priority`** — `urgent`, `high`, `medium`, `low`, or `""` (no priority). Mutable through the plan's whole life. Soft selection signal: among plans not blocked by relations, pick the highest priority first. It complements, never overrides, `blocked_by` gating — a blocked plan is not selectable regardless of priority.
+
+### Tracker sync
+
+`tracked_in` links a plan to its mirror artifact in an external tracker — issue, task, card, epic: the URL is self-describing (e.g. `"https://linear.app/acme/issue/ENG-135"`). Written by sync tooling on local runs; `""` means not tracked. Multiple trackers: comma-separated URLs, **one mirror per tracker** — two mirrors in the same tracker signals the plan should be split, not a supported case.
+
+The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias `workplan:<id>`; new mirrors write `plan:<id>` only). The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
+
+Source-of-truth split: the markdown owns plan content, state, and dates; the tracker owns its visual organization (projects, milestones, tracker-side assignment), which sync never overwrites. A child plan's epic/project derives from the `tracked_in` of its `parent` target. Rule 18 is unchanged: `tracked_in` covers only the plan-level mirror; inline issue links stay in prose.
 
 ### Sections
 
-Five H2 sections, Title Case. Order depends on `format_version`:
+Five H2 sections, Title Case. Order depends on the plan's declared format:
 
-| `format_version` | Order |
-|------------------|-------|
+| `format` | Order |
+|----------|-------|
 | `0.3.0` or higher (new layout) | `Objective` → `Progress` → `Context` → `Implementation` → `Closing Summary` |
 | `0.2.x` or lower (legacy layout) | `Progress` → `Objective` → `Context` → `Implementation` → `Closing Summary` |
 
@@ -130,9 +175,19 @@ Five H2 sections, Title Case. Order depends on `format_version`:
 | `## Progress` | Checklist mirror of Implementation phases |
 | `## Context` | Background, constraints, or references |
 | `## Implementation` | Technical detail organized by phase |
-| `## Closing Summary` | Bullet points written when the last phase is completed. Until then: `_To be written when the last phase is completed._` |
+| `## Closing Summary` | Leader paragraph plus optional labeled subsections (see Closing Summary structure). Until then: `_To be written when the last phase is completed._` |
 
 H1 is the first line after the frontmatter and must match `title` exactly. One H1 per file.
+
+### Execution sequence
+
+Optional subsection at the end of `## Progress` (after all phase checklists), only for plans with 5+ phases where grouping adds value: lettered blocks naming what to execute together and in what order. Non-invasive — phases keep their numbering and `### Phase N: Name` hierarchy unchanged.
+
+```markdown
+### Execution sequence
+- **A: Infrastructure** — Phase 1
+- **B: Base components** — Phases 2, 3
+```
 
 ### Mandatory phases
 
@@ -166,9 +221,35 @@ A plan in `backlog/` with Phase 1 unchecked is still being defined. A plan canno
 
 The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions that also translate to the user's language. English canonical: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` The same entries in Spanish: `Define el Objective, el Context y las fases subsiguientes. Una vez completas, el plan queda listo para ejecución.` and `Valida la implementación con el usuario y escribe el Closing Summary. Una vez completa, el plan queda listo para moverse a done.` Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
 
+### Closing Summary structure
+
+The Closing Summary opens with a mandatory **leader paragraph** — the literal export unit: changelog entries, mirror closing comments, and any other projection copy it verbatim, never rewrite it. Nothing that does not travel outside the repo may appear:
+
+1. Opens with the result, never the process.
+2. No actor — no people, models, or team: impersonal constructions or the deliverable as subject.
+3. No references that do not travel: phase numbers, plan ids, repo-internal paths.
+4. No temporal deictics ("today", "this week").
+5. No links — pointers live in `References`.
+6. 3-6 sentences, hard cap.
+7. Litmus test: it must read correctly on a release page with zero context.
+
+After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
+
+| Label | Content |
+|-------|---------|
+| `Delivered` | What shipped |
+| `Decisions` | Decisions taken and deviations from the plan |
+| `Verification` | How the result was verified |
+| `Deferred` | Work moved out; every item names its destination plan id |
+| `References` | Delivery evidence links (PR, deploy, published doc), one per bullet, labeled, absolute URLs only |
+
+Only the leader paragraph is unconditionally mandatory. `References` is conditionally mandatory — present if the work produced verifiable artifacts, omitted when there is no linkable evidence, never left empty. The other four are purely optional. Custom labels only when no recommended label fits — never a synonym of an existing one — in English, under the same rules. Total budget: ~40 lines. Banned: signatures, model attribution in prose, evaluative blocks.
+
+**Extraction contract.** A closed plan guarantees: `id`, `title`, `done_date`, the leader paragraph, and parseable subsections. Derived changelog entries and mirror closing comments copy the leader paragraph verbatim and append the `References` links. The framework ships no CHANGELOG.md — generation is tooling. Pre-existing manual changelogs freeze as legacy for older-format plans; derivation applies going forward only.
+
 ## Rules
 
-All 27 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 34 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -176,11 +257,11 @@ All 27 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 2 | Structure | The timestamp portion of the filename and the matching `id` are immutable. The description portion of the filename is mutable when `title` changes substantially — see File naming |
 | 3 | Structure | `workplans/` only contains structured plan files. No notes, docs, or unstructured content |
 | 4 | Structure | Do not create files or folders that alter the `workplans/` structure |
-| 5 | Structure | README files and RULES.md are system files. Do not remove or edit manually |
+| 5 | Structure | RULES.md and the state-folder READMEs are system files: do not remove or edit manually. The root README.md is user-owned after init and carries the project constants |
 | 6 | Structure | Do not add custom frontmatter fields or markdown sections beyond the defined format |
 | 7 | Template | H1 must match the `title` field |
-| 8 | Template | H2 sections must use Title Case. Only 5 valid sections. Section order depends on `format_version` |
-| 9 | Template | Progress phases mirror Implementation phases. Legacy layout (`format_version < 0.3.0`) puts Progress first; new layout (`>= 0.3.0`) puts Objective first |
+| 8 | Template | H2 sections must use Title Case. Only 5 valid sections. Section order depends on the plan's declared format |
+| 9 | Template | Progress phases mirror Implementation phases. Legacy layout (format `< 0.3.0`) puts Progress first; new layout (`>= 0.3.0`) puts Objective first |
 | 10 | Template | Phase 1: Definition is mandatory with three fixed steps. Must not be modified |
 | 11 | Template | Closing phase is mandatory as the last phase with two fixed steps. Must not be modified |
 | 12 | Template | Steps grouped by phase (`### Phase N: Name`), each concrete and verifiable. Use "Phase" and "Step" only (never "Stage") |
@@ -194,11 +275,18 @@ All 27 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 20 | Data | Datetimes must come from the system clock. Hardcoded, estimated, or placeholder values are forbidden |
 | 21 | Data | `author` is immutable once assigned; multiple authors are comma-separated |
 | 22 | Data | `_` separates timestamp ID from description; uniqueness = timestamp + description |
-| 23 | Data | `format_version` reflects the current format. At creation, equals RULES.md `version`. Mutable only on explicit migration; signals which rule set validators apply |
+| 23 | Data | `format` reflects the current format. At creation, equals RULES.md `version`. Mutable only on explicit migration; signals which rule set validators apply |
 | 24 | Template | Plan files must not contain emojis. Use plain descriptive text instead |
 | 25 | Template | Steps that cannot be executed by an AI agent (browser checks, external dashboard configuration, manual UI testing, credential rotation) must be prefixed with `[manual]`. The agent skips them and reports to the user; Implementation describes what the user needs to do |
 | 26 | Structure | When the workplans folder is inside a Git repository (or any VCS with branch semantics), the branch for a new plan is decided explicitly before commit: declared policy in agent file → current non-main branch → ask the user. Never default silently to `main`. Outside a VCS, this rule does not apply |
-| 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language. Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
+| 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language, preserving full orthography (accents, diacritics). Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
+| 28 | Data | `relations` sub-keys are limited to `blocked_by`, `relates_to`, `supersedes`, `parent`. Targets are immutable plan `id`s, comma-separated; no titles or slugs |
+| 29 | Template | A plan with a non-empty `blocked_by` must not move to `doing/` until every referenced plan is `done`. Cycles are invalid |
+| 30 | Data | `estimate` is set when Phase 1: Definition completes, must belong to the declared scale's token set, and is immutable once in `doing/` |
+| 31 | Data | `priority` is `urgent`, `high`, `medium`, `low`, or `""`. Mutable; a blocked plan is not selectable regardless of priority |
+| 32 | Data | `tracked_in` holds the mirror URL(s), one per tracker, comma-separated. Written by sync tooling, not edited manually |
+| 33 | Template | A done plan's Closing Summary opens with the leader paragraph and groups detail only under the recommended vocabulary — see Closing Summary structure |
+| 34 | Structure | Subfolders inside `workplans/` beyond the state folders and `extend/` are invalid — single-project layout only in this version |
 
 ## File naming
 
@@ -214,13 +302,7 @@ Example: `2606455842_user-auth-setup.md` (2026, day 064, 15:30:42).
 
 State transitions never rename. Renaming the description segment is a separate, deliberate action triggered by a `title` change — use `git mv` so blame stays continuous.
 
-**Dot→dash:** any dot inside a number or version identifier in the description must be replaced with a dash to preserve digit boundaries in kebab-case. Examples:
-
-| Case | Wrong (compact) | Right (dot→dash) |
-|------|-----------------|------------------|
-| Version `v0.2.2` | `v022` | `v0-2-2` |
-| Node `18.2` | `node182` | `node-18-2` |
-| Decimal `3.14` | `314` | `3-14` |
+**Dot→dash:** any dot inside a number or version identifier in the description must be replaced with a dash to preserve digit boundaries in kebab-case. Examples: version `v0.2.2` → `v0-2-2` (never `v022`), decimal `3.14` → `3-14`.
 
 ### Timestamp generation
 
@@ -268,15 +350,35 @@ The client suffix is omitted when the agent runs directly (API, Claude Code, web
 - **Template structure** (H2 headings, `Phase` keyword) and **filenames** are always in English.
 - **Frontmatter field names** are always in English — part of the schema.
 - **User-authored content** (title, descriptions, steps, summary) follows the user's active conversation language.
-- **Orthography** must be preserved: accents, ñ, and other special characters of the user's language. UTF-8 is the encoding for Markdown files.
+- **Orthography** carries the full spelling of the user's language — accents, ñ, and any diacritics — in every content position: phase titles, step text, and body prose alike ("Definición", never "Definicion"). ASCII-only applies solely to filenames (kebab-case), never to content. UTF-8 is the encoding for Markdown files.
+
+## Project constants
+
+The frontmatter of the root `workplans/README.md` is the only project-level config location; RULES.md frontmatter carries framework metadata only (`name`, `version`). All constants are optional with defaults — in the common case the frontmatter does not exist at all, appearing the first time there is something to declare:
+
+```yaml
+---
+work_on: "https://github.com/acme/backend"
+tracker: "https://linear.app/acme/team/ENG"
+estimate_scale: "fibonacci"
+---
+```
+
+| Constant | Absent means |
+|----------|--------------|
+| `work_on` | Plans target this same repo (equivalent to `"."`) |
+| `tracker` | No tracker sync |
+| `estimate_scale` | `fibonacci` |
+
+The root `README.md` is user-owned after init: framework updates never modify an existing root README (state-folder READMEs remain system files). There is no `name` constant (machine name = folder/repo; display name = the README's H1) and no provider constant (the `tracker` URL's domain selects the sync adapter).
 
 ## Work destination
 
-The `work_on` field in RULES.md frontmatter declares where plan execution applies. Valid values:
+The `work_on` constant declares where plan execution applies. Valid values:
 
 | Value | Meaning |
 |-------|---------|
-| `"."` (default) | Parent directory of `workplans/`. Plans target the same project |
+| `"."` or absent (default) | Parent directory of `workplans/`. Plans target the same project |
 | Remote URL | Plans target a different project (e.g. `https://github.com/org/project`) |
 
 Two destinations for changes:
@@ -286,9 +388,11 @@ Two destinations for changes:
 | Plan files (Markdown, frontmatter, folder moves) | Inside `workplans/` |
 | Plan execution (code, configs, assets) | At `work_on` |
 
-Only `"."` or a remote URL are valid in RULES.md — never local paths (they differ across machines).
+Only `"."` or a remote URL are valid — never local paths (they differ across machines).
 
 When `work_on` is a remote URL, the local path is resolved into `workplans/LOCAL.yml` (auto-generated, gitignored, never committed). When both repos must be configured (plans live in one, code in another), the target repo's agent file (AGENTS.md / CLAUDE.md) must point back to where the plans live. See [README.md](README.md#work-destination) for the full resolution flow.
+
+**Execution conventions.** When the planning and execution repos are separate, the target repo's agent file (AGENTS.md, CLAUDE.md, or equivalent) is the source of truth for execution: git workflow, branching, commit and PR format, language. The planning repo's agent file governs only the plan files; on conflict, the target's prevails for everything execution-related. Read it before committing there; if the target repo has none, report it and ask the user instead of assuming the planning repo's conventions.
 
 ## Extensions
 
@@ -296,4 +400,23 @@ Optional extensions live in `workplans/extend/`, one subfolder per extension. Th
 
 ## Compatibility
 
-The `version` field declares the active framework version. Plans declare their own `format_version`; validators apply the rule set matching that value, so plans from different framework versions coexist. Plans without `format_version` are implicitly pre-0.2.1 (legacy layout, Progress first).
+The `version` field declares the active framework version. Plans declare their own `format` (read-alias `format_version`); validators apply the rule set matching that value, so plans from different framework versions coexist. Plans without either field are implicitly pre-0.2.1 (legacy layout, Progress first).
+
+### Migration
+
+When a plan's declared format is older than the framework `version`, the agent asks the user whether to migrate it — never silently. If the user declines, record the decision for the session and do not ask again.
+
+| Folder | Migration |
+|--------|-----------|
+| `backlog/` | Offered by default |
+| `doing/` | Only on explicit user request |
+| `done/` | Never — historical record, immutable with its original format |
+
+Migration alters frontmatter and section order only — checkboxes, dates, and user content are preserved verbatim — and updates the format field to the current version in the same change. The CLI exposes the same operation as `workplans migrate` for reproducibility.
+
+### Supported transitions
+
+| From | To | Transformation |
+|------|----|----------------|
+| pre-0.2.1, 0.2.x | 0.3.0 | Reorder the five H2 sections to the new layout (Objective first); set `format_version: "0.3.0"` |
+| 0.3.x | 0.4.0 | Rename `format_version` → `format`, reorder fields to the 0.4.0 order, add `priority`/`estimate`/`tracked_in` as `""` and the bare `relations:` key |

--- a/demo/workplans/backlog/2601551600_user-auth-setup.md
+++ b/demo/workplans/backlog/2601551600_user-auth-setup.md
@@ -1,15 +1,20 @@
 ---
+format: "0.4.0"
 id: 2601551600
 title: "User authentication setup"
-state: "backlog"
+priority: "high"
+estimate: 5
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-01-15T14:20"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  blocked_by: "2602836000"
 ---
 
 # User authentication setup

--- a/demo/workplans/backlog/2602836000_notification-system.md
+++ b/demo/workplans/backlog/2602836000_notification-system.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2602836000
 title: "Email notification system"
-state: "backlog"
+priority: "high"
+estimate: 3
 author: "sebastianserna"
 author_model: "mistral-large"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-01T09:15"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Email notification system

--- a/demo/workplans/backlog/2604141400_api-rate-limiting.md
+++ b/demo/workplans/backlog/2604141400_api-rate-limiting.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2604141400
 title: "API rate limiting strategy"
-state: "backlog"
+priority: "low"
+estimate: 3
 author: "sebastianserna"
 author_model: ""
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-10T11:30"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # API rate limiting strategy

--- a/demo/workplans/backlog/2604655800_dark-mode-design.md
+++ b/demo/workplans/backlog/2604655800_dark-mode-design.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2604655800
 title: "Dark mode design system"
-state: "backlog"
+priority: ""
+estimate: 2
 author: "sebastianserna"
 author_model: "gpt-4o"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-15T15:30"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Dark mode design system

--- a/demo/workplans/backlog/2604739600_search-functionality.md
+++ b/demo/workplans/backlog/2604739600_search-functionality.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2604739600
 title: "Full-text search functionality"
-state: "backlog"
+priority: "medium"
+estimate: 8
 author: "sebastianserna"
 author_model: ""
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-20T15:45"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Full-text search functionality

--- a/demo/workplans/backlog/2604952200_role-permissions.md
+++ b/demo/workplans/backlog/2604952200_role-permissions.md
@@ -1,15 +1,20 @@
 ---
+format: "0.4.0"
 id: 2604952200
 title: "Role-based permissions"
-state: "backlog"
+priority: "medium"
+estimate: 5
 author: "sebastianserna"
 author_model: "gemini-2.5-pro"
 assignee: "alexgarcia"
 assignee_model: "gpt-4o"
+state: "backlog"
 backlog_date: "2026-02-22T09:25"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  relates_to: "2601551600"
 ---
 
 # Role-based permissions

--- a/demo/workplans/backlog/2605639600_file-upload-system.md
+++ b/demo/workplans/backlog/2605639600_file-upload-system.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2605639600
 title: "File upload system"
-state: "backlog"
+priority: ""
+estimate: 5
 author: "sebastianserna"
 author_model: "grok-3"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-25T11:00"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # File upload system

--- a/demo/workplans/backlog/README.md
+++ b/demo/workplans/backlog/README.md
@@ -14,17 +14,21 @@ A newly created plan. The agent has defined the objective, context, and phases â
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "backlog"
+priority: ""
+estimate: ""
 author: "Sebastian Serna"
 author_model: "claude-opus-4-6"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-03-05T09:30"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup

--- a/demo/workplans/doing/2601557600_dashboard-redesign.md
+++ b/demo/workplans/doing/2601557600_dashboard-redesign.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2601557600
 title: "Dashboard redesign"
-state: "doing"
+priority: "high"
+estimate: 8
 author: "sebastianserna"
 author_model: "claude-opus-4, gemini-pro"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "doing"
 backlog_date: "2026-01-20T10:00"
 doing_date: "2026-02-10T09:30"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Dashboard redesign

--- a/demo/workplans/doing/2603334200_api-v2-endpoints.md
+++ b/demo/workplans/doing/2603334200_api-v2-endpoints.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2603334200
 title: "API v2 endpoints"
-state: "doing"
+priority: "high"
+estimate: 8
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: "alexgarcia"
 assignee_model: "claude-opus-4"
+state: "doing"
 backlog_date: "2026-02-05T11:00"
 doing_date: "2026-02-18T09:00"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # API v2 endpoints

--- a/demo/workplans/doing/2603440500_websocket-realtime.md
+++ b/demo/workplans/doing/2603440500_websocket-realtime.md
@@ -1,15 +1,20 @@
 ---
+format: "0.4.0"
 id: 2603440500
 title: "WebSocket real-time updates"
-state: "doing"
+priority: "medium"
+estimate: 5
 author: "sebastianserna"
 author_model: "deepseek-v3"
 assignee: "alexgarcia"
 assignee_model: "grok-3"
+state: "doing"
 backlog_date: "2026-02-05T14:00"
 doing_date: "2026-02-20T10:30"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  relates_to: "2603334200"
 ---
 
 # WebSocket real-time updates

--- a/demo/workplans/doing/README.md
+++ b/demo/workplans/doing/README.md
@@ -14,17 +14,21 @@ The same plan now in progress. Phase 1 is complete, assignee is set, and Phase 2
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "doing"
+priority: "high"
+estimate: 5
 author: "Sebastian Serna"
 author_model: "claude-opus-4-6"
 assignee: "Sebastian Serna"
 assignee_model: "claude-sonnet-4-6"
+state: "doing"
 backlog_date: "2026-03-05T09:30"
 doing_date: "2026-03-06T14:00"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup

--- a/demo/workplans/done/2600532400_project-setup.md
+++ b/demo/workplans/done/2600532400_project-setup.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2600532400
 title: "Initial project setup"
-state: "done"
+priority: ""
+estimate: 3
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "done"
 backlog_date: "2026-01-05T09:00"
 doing_date: "2026-01-10T10:00"
 done_date: "2026-01-30T14:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Initial project setup
@@ -49,6 +53,12 @@ Node.js 20 with TypeScript strict mode. ESLint with Airbnb config. PostgreSQL 16
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- All tooling and CI pipeline set up and verified
-- CI pipeline is green, team can start building features
-- Docker Compose environment works for all team members
+The project now has a complete development foundation: repository tooling, a Docker Compose environment that runs identically for every team member, and a green CI pipeline. New features can be built and verified from day one without additional setup.
+
+### Delivered
+- Repository tooling and linting configuration
+- Docker Compose development environment
+- CI pipeline running on every push
+
+### Verification
+- CI green; environment verified by every team member

--- a/demo/workplans/done/2600532400_project-setup.md
+++ b/demo/workplans/done/2600532400_project-setup.md
@@ -53,7 +53,7 @@ Node.js 20 with TypeScript strict mode. ESLint with Airbnb config. PostgreSQL 16
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-The project now has a complete development foundation: repository tooling, a Docker Compose environment that runs identically for every team member, and a green CI pipeline. New features can be built and verified from day one without additional setup.
+The project now has a complete development foundation. The repository ships its tooling, a Docker Compose environment that runs identically for every team member, and a CI pipeline that verifies every push. New features can be built and verified from day one without additional setup.
 
 ### Delivered
 - Repository tooling and linting configuration

--- a/demo/workplans/done/2601036900_database-schema.md
+++ b/demo/workplans/done/2601036900_database-schema.md
@@ -1,15 +1,20 @@
 ---
+format: "0.4.0"
 id: 2601036900
 title: "Database schema design"
-state: "done"
+priority: "high"
+estimate: 5
 author: "sebastianserna"
 author_model: "gpt-4o"
 assignee: "alexgarcia"
 assignee_model: "gpt-4o"
+state: "done"
 backlog_date: "2026-01-10T10:15"
 doing_date: "2026-01-20T09:00"
 done_date: "2026-02-08T11:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  blocked_by: "2600532400"
 ---
 
 # Database schema design
@@ -49,7 +54,10 @@ PostgreSQL with UUIDs as primary keys. All tables include `created_at` and `upda
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- Schema finalized and deployed to staging
-- All migrations run cleanly on fresh databases
-- Seed data populates correctly for development
-- Foreign key constraints and query performance verified
+The database schema is finalized and deployed to staging. Migrations run cleanly on fresh databases and seed data populates correctly for development. Foreign key constraints and query performance are verified.
+
+### Delivered
+- Normalized schema with migrations and seed data
+
+### Verification
+- Fresh-database migration runs, constraint checks, and query benchmarks

--- a/demo/workplans/done/2601632400_logging-monitoring.md
+++ b/demo/workplans/done/2601632400_logging-monitoring.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2601632400
 title: "Logging and monitoring setup"
-state: "done"
+priority: "medium"
+estimate: 5
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "done"
 backlog_date: "2026-01-20T11:00"
 doing_date: "2026-02-01T10:00"
 done_date: "2026-02-15T15:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Logging and monitoring setup
@@ -58,7 +62,11 @@ Health check at `/health` reports database, Redis, and external service status. 
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- Winston logging with request ID correlation deployed across all services
-- Health check correctly reports degraded state when dependencies are slow
-- Grafana dashboards show p50, p95, p99 latency with alert thresholds
-- Alerts fire when error rate exceeds 5% over 5 minutes
+All services now emit structured logs with request ID correlation, and the health check reports a degraded state when dependencies are slow. Dashboards expose p50, p95, and p99 latency with alert thresholds, and alerts fire when the error rate exceeds 5% over 5 minutes.
+
+### Delivered
+- Winston logging with request ID correlation across all services
+- Grafana dashboards and alerting rules
+
+### Verification
+- Degraded-state reporting and alert firing tested end to end

--- a/demo/workplans/done/2601632400_logging-monitoring.md
+++ b/demo/workplans/done/2601632400_logging-monitoring.md
@@ -62,7 +62,7 @@ Health check at `/health` reports database, Redis, and external service status. 
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-All services now emit structured logs with request ID correlation, and the health check reports a degraded state when dependencies are slow. Dashboards expose p50, p95, and p99 latency with alert thresholds, and alerts fire when the error rate exceeds 5% over 5 minutes.
+All services now emit structured logs with request ID correlation. The health check reports a degraded state when dependencies are slow. Dashboards expose p50, p95, and p99 latency with alert thresholds, and alerts fire when the error rate exceeds 5% over 5 minutes.
 
 ### Delivered
 - Winston logging with request ID correlation across all services

--- a/demo/workplans/done/2602250400_ci-pipeline.md
+++ b/demo/workplans/done/2602250400_ci-pipeline.md
@@ -1,15 +1,19 @@
 ---
+format: "0.4.0"
 id: 2602250400
 title: "CI/CD pipeline improvements"
-state: "done"
+priority: "medium"
+estimate: 3
 author: "sebastianserna"
 author_model: "mistral-large"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "done"
 backlog_date: "2026-01-25T09:30"
 doing_date: "2026-02-10T08:30"
 done_date: "2026-02-20T10:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # CI/CD pipeline improvements
@@ -56,7 +60,11 @@ Staging auto-deploys on merge to main via GitHub Actions. Production deploys req
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- CI pipeline reduced from 12 min to 3.5 min with caching and parallel jobs
-- Staging auto-deploy verified and working on merge to main
-- Production deploy with approval gate tested successfully
-- Rollback mechanism documented and tested
+The CI pipeline now completes in 3.5 minutes, down from 12, through caching and parallel jobs. Merges to main deploy to staging automatically, production deploys sit behind an approval gate, and a documented rollback mechanism is in place.
+
+### Delivered
+- Cached, parallelized CI pipeline
+- Staging auto-deploy and gated production deploy
+
+### Verification
+- Staging auto-deploy, production approval gate, and rollback tested

--- a/demo/workplans/done/2602250400_ci-pipeline.md
+++ b/demo/workplans/done/2602250400_ci-pipeline.md
@@ -60,7 +60,7 @@ Staging auto-deploys on merge to main via GitHub Actions. Production deploys req
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-The CI pipeline now completes in 3.5 minutes, down from 12, through caching and parallel jobs. Merges to main deploy to staging automatically, production deploys sit behind an approval gate, and a documented rollback mechanism is in place.
+The CI pipeline now completes in 3.5 minutes, down from 12, through caching and parallel jobs. Merges to main deploy to staging automatically, while production deploys sit behind an approval gate. A documented rollback mechanism is in place.
 
 ### Delivered
 - Cached, parallelized CI pipeline

--- a/demo/workplans/done/README.md
+++ b/demo/workplans/done/README.md
@@ -10,21 +10,25 @@ Done plans should generally not be modified. If a completed plan needs rework, c
 
 ## Example plan in done
 
-The same plan fully completed. All steps are checked, done_date is set, and the Closing Summary is written.
+The same plan fully completed. All steps are checked, done_date is set, and the Closing Summary is written: a leader paragraph (exported verbatim to changelogs and tracker comments) followed by labeled subsections.
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "done"
+priority: "high"
+estimate: 5
 author: "Sebastian Serna"
 author_model: "claude-opus-4-6"
 assignee: "Sebastian Serna"
 assignee_model: "claude-sonnet-4-6"
+state: "done"
 backlog_date: "2026-03-05T09:30"
 doing_date: "2026-03-06T14:00"
 done_date: "2026-03-07T18:45"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup
@@ -69,8 +73,23 @@ Added Express middleware in `src/middleware/auth.ts` that validates JWT on all `
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- Implemented JWT authentication with RS256, refresh token rotation, and Google OAuth (PKCE)
-- Added three auth endpoints and middleware for protected routes
-- No deviations from the original plan
-- Future work: add rate limiting on auth endpoints and support additional OAuth providers
+The web application now authenticates users with JWT sessions, email/password
+registration, and Google OAuth sign-in. Access is renewed through single-use
+refresh tokens, and every protected API route validates the session through
+shared middleware. Passwords are hashed with bcrypt and tokens are stored in
+httpOnly secure cookies.
+
+### Delivered
+- Authentication middleware protecting all API routes
+- Registration, login, and Google OAuth endpoints with integration tests
+
+### Decisions
+- RS256 signing over HS256, for key rotation support
+- Tokens in httpOnly cookies instead of localStorage
+
+### Deferred
+- Rate limiting on auth endpoints, registered in plan 2606980112
+
+### References
+- PR: https://github.com/acme/backend/pull/87
 ```

--- a/init/workplans/README.md
+++ b/init/workplans/README.md
@@ -65,17 +65,63 @@ State transitions (`backlog/` → `doing/` → `done/`) never rename. They only 
 
 ## Versioning and compatibility
 
-The `version` field in [RULES.md](RULES.md) declares the active framework version. Each plan declares its own `format_version` at creation, and validators apply the rule set matching that value. This means:
+The `version` field in [RULES.md](RULES.md) declares the active framework version. Each plan declares its own `format` at creation (named `format_version` before 0.4.0 — parsers accept both), and validators apply the rule set matching that value. This means:
 
 - Plans created under different framework versions can coexist in the same repository.
-- Migrating a plan to a new format is opt-in per plan; legacy plans keep working.
+- Migrating a plan to a new format is opt-in per plan; legacy plans keep working. Agents offer migration for `backlog/` plans, migrate `doing/` plans only on request, and never touch `done/`.
 - Historical plans in `done/` retain their original layout — they are artifacts, not living documents.
 
-Plans without `format_version` are treated as pre-0.2.1 legacy.
+Plans without a format field are treated as pre-0.2.1 legacy.
+
+## Closing Summary: voice and example
+
+The Closing Summary's leader paragraph is exported verbatim to changelogs and tracker closing comments, so it is written for a reader with zero context. The craft is in what it avoids:
+
+- **Open with the result, never the process.** "The sync command now mirrors plans into Linear" — not "During this plan we worked on sync".
+- **No actor.** Impersonal constructions or the deliverable as subject; people and models already live in the frontmatter.
+- **Nothing that doesn't travel.** Phase numbers, plan ids, and internal paths mean nothing on a release page. Time references ("today", "this week") go stale. Links belong in `References`.
+
+The labels (`Delivered`, `Decisions`, `Verification`, `Deferred`, `References`) are always English; the prose follows the user's language — the voice criteria are language-independent. Canonical example:
+
+```markdown
+## Closing Summary
+The sync command now mirrors plans into Linear with idempotent re-runs: every
+mirror issue carries a plan marker, so interrupted or repeated syncs never
+duplicate issues. Closed plans post their summary as a closing comment
+automatically. Setup requires a single tracker URL in the project constants.
+
+### Delivered
+- Sync command with create and update modes
+- Linear adapter with marker-based idempotency
+
+### Decisions
+- Backdating applies only at creation; updates never rewrite tracker history
+
+### Deferred
+- GitHub adapter, registered in plan 2619460001
+
+### References
+- PR: https://github.com/acme/backend/pull/142
+- Docs: https://acme.dev/docs/sync
+```
+
+## Project constants
+
+This README's own frontmatter is the home of project-level configuration — markdown-with-frontmatter is the framework's native idiom, and this file is user-owned after init, so updates never overwrite what you declare here. Three constants, all optional:
+
+```yaml
+---
+work_on: "https://github.com/acme/backend"
+tracker: "https://linear.app/acme/team/ENG"
+estimate_scale: "fibonacci"
+---
+```
+
+Absent `work_on` means plans target this same repo; absent `tracker` means no sync; absent `estimate_scale` means Fibonacci. A new project needs none of them — the frontmatter appears the first time there is something to declare.
 
 ## Work destination
 
-The `work_on` field in RULES.md frontmatter tells agents where plan execution applies. Two scenarios:
+The `work_on` project constant tells agents where plan execution applies. Two scenarios:
 
 **Same repo (`work_on: "."`)** — plans and code live in the same project. The agent reads plans from `workplans/` and applies code changes in the parent directory.
 
@@ -104,10 +150,12 @@ work_on: "/Users/me/repos/org/project"
 
 When `work_on` is a remote URL, both repos need to be configured:
 
-- **Planning repo** — `work_on` in RULES.md points to the target project.
+- **Planning repo** — the `work_on` constant in this README's frontmatter points to the target project.
 - **Target repo** — its agent file (AGENTS.md / CLAUDE.md) declares where plans are managed.
 
 Without the target-side instruction, an agent working in the target repo will not know plans exist elsewhere and may try to create them locally.
+
+The target repo's agent file is also the source of truth for execution conventions — branching, commit and PR format, language. The planning repo's conventions govern only the plan files.
 
 ## Extensions
 

--- a/init/workplans/README.md
+++ b/init/workplans/README.md
@@ -68,7 +68,7 @@ State transitions (`backlog/` → `doing/` → `done/`) never rename. They only 
 The `version` field in [RULES.md](RULES.md) declares the active framework version. Each plan declares its own `format` at creation (named `format_version` before 0.4.0 — parsers accept both), and validators apply the rule set matching that value. This means:
 
 - Plans created under different framework versions can coexist in the same repository.
-- Migrating a plan to a new format is opt-in per plan; legacy plans keep working. Agents offer migration for `backlog/` plans, migrate `doing/` plans only on request, and never touch `done/`.
+- Migrating a plan to a new format is opt-in per plan; legacy plans keep working. Agents offer migration for `backlog/` plans, migrate `doing/` plans only on request, and never touch `done/`. The same operation is reproducible via `npx workplans migrate`.
 - Historical plans in `done/` retain their original layout — they are artifacts, not living documents.
 
 Plans without a format field are treated as pre-0.2.1 legacy.

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -57,6 +57,7 @@ state: "backlog"
 backlog_date: "YYYY-MM-DDThh:mm"
 doing_date: ""
 done_date: ""
+relations:
 ---
 
 # User authentication setup
@@ -116,6 +117,30 @@ The field order tells one story: what it is, who, where it stands. `format` goes
 | `backlog_date` | Datetime created (`YYYY-MM-DDThh:mm`) |
 | `doing_date` | Datetime work started |
 | `done_date` | Datetime completed |
+| `relations` | Typed relations to other plans. Nested map; empties to the bare key (`relations:` with no value). See Relations |
+
+### Relations
+
+`relations` is a nested map: keys are relation types, values are comma-separated plan `id`s.
+
+```yaml
+relations:
+  blocked_by: "2606455842,2606123456"
+  relates_to: "2606123456"
+```
+
+| Type | Meaning |
+|------|---------|
+| `blocked_by` | Hard dependency: every referenced plan must be `done` before this plan moves to `doing` |
+| `relates_to` | Soft, non-blocking association |
+| `supersedes` | This plan replaces the referenced plan(s) |
+| `parent` | Hierarchy: the `id` of the parent/epic plan |
+
+- References are id-pure: the immutable plan `id` only, never titles or filename slugs. Tooling resolves ids to titles at display time.
+- Only the types in use appear as sub-keys. With no relations, the field is the bare key: `relations:` with no value (parses to null).
+- Inverse relations (`blocks`, `superseded_by`, `children`) are derived by tooling, never stored. Each edge is written on the actionable side only.
+- Cycles in `blocked_by` are invalid.
+- `relations` is the only nested frontmatter field: nesting is reserved for open-ended membership; all other fields stay flat scalars.
 
 ### Sections
 
@@ -170,7 +195,7 @@ The Implementation entries for Phase 1 and Closing use fixed plain-text descript
 
 ## Rules
 
-All 27 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 29 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -201,6 +226,8 @@ All 27 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 25 | Template | Steps that cannot be executed by an AI agent (browser checks, external dashboard configuration, manual UI testing, credential rotation) must be prefixed with `[manual]`. The agent skips them and reports to the user; Implementation describes what the user needs to do |
 | 26 | Structure | When the workplans folder is inside a Git repository (or any VCS with branch semantics), the branch for a new plan is decided explicitly before commit: declared policy in agent file → current non-main branch → ask the user. Never default silently to `main`. Outside a VCS, this rule does not apply |
 | 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language. Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
+| 28 | Data | `relations` sub-keys are limited to `blocked_by`, `relates_to`, `supersedes`, `parent`. Targets are immutable plan `id`s, comma-separated; no titles or slugs |
+| 29 | Template | A plan with a non-empty `blocked_by` must not move to `doing/` until every referenced plan is `done`. Cycles in `blocked_by` are invalid |
 
 ## File naming
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -34,7 +34,7 @@ State transitions move the file and update frontmatter; they never rename. The f
 
 The branch a plan is committed on is an explicit decision, not a side-effect of the current shell state. Resolve in order, stop at the first match. The VCS check (step 2) only fires when no policy is declared — a declared policy implies a VCS is present, so no further verification is needed:
 
-1. **Policy declared** in the agent file (AGENTS.md, CLAUDE.md, etc.) → follow it. A planning-only repo may declare a main-only policy (e.g. "all plans commit directly to main; no feature branches for plan files"), which keeps every plan visible on the main branch.
+1. **Policy declared** in the agent file (AGENTS.md, CLAUDE.md, etc.) → follow it. A planning-only repo may declare a main-only policy ("all plans commit directly to main") so plans never fragment across branches.
 2. **No VCS detected** (`git rev-parse --is-inside-work-tree` does not return `true`) → write the plan to disk, no branch question.
 3. **VCS + current branch is not the main branch** → commit on the current branch.
 4. **VCS + current branch is main** → ask the user whether to create a new branch first or commit on main.
@@ -104,15 +104,13 @@ The template is in English as reference only. The `Phase N:` prefix and the five
 
 Frontmatter starts on line 1, no leading blank lines. All fields present, in the order below; scalar fields empty to `""`.
 
-The field order tells one story: what it is, who, where it stands. `format` goes first — it is the discriminator that says which schema governs the rest of the file.
-
 | Field | Description |
 |-------|-------------|
-| `format` | Format the plan follows. At creation, equals `version` in RULES.md. Mutable only on explicit migration. Read-alias: `format_version` (the pre-0.4.0 name; parsers accept both, new plans write `format`) |
+| `format` | Format the plan follows; the discriminator that says which schema governs the rest of the file, hence first. At creation, equals `version` in RULES.md. Read-alias: `format_version` (pre-0.4.0 name) |
 | `id` | Timestamp ID matching the filename (`YYDDDsssss`). Immutable |
 | `title` | Short descriptive title |
-| `priority` | Urgency signal: `urgent`, `high`, `medium`, `low`, or `""` (no priority). Mutable through the plan's whole life. See Triage |
-| `estimate` | Complexity in the project's declared estimate scale. Set when Phase 1: Definition completes; immutable once the plan is in `doing/`. See Triage |
+| `priority` | Urgency: `urgent`, `high`, `medium`, `low`, or `""`. Mutable for life. See Triage |
+| `estimate` | Complexity in the project's declared scale. Set when Phase 1 completes; immutable in `doing/`. See Triage |
 | `author` | Human creator. Immutable. Comma-separated if multiple (e.g. `"Alice,Bob"`) |
 | `author_model` | AI model ID(s) that created the plan. See AI model attribution |
 | `assignee` | Person implementing |
@@ -121,7 +119,7 @@ The field order tells one story: what it is, who, where it stands. `format` goes
 | `backlog_date` | Datetime created (`YYYY-MM-DDThh:mm`) |
 | `doing_date` | Datetime work started |
 | `done_date` | Datetime completed |
-| `tracked_in` | URL(s) of the plan's mirror artifact in external tracker(s). Written by sync tooling; `""` = not tracked. See Tracker sync |
+| `tracked_in` | Mirror URL(s) in external tracker(s), written by sync tooling; `""` = not tracked. See Tracker sync |
 | `relations` | Typed relations to other plans. Nested map; empties to the bare key (`relations:` with no value). See Relations |
 
 ### Relations
@@ -142,8 +140,8 @@ relations:
 | `parent` | Hierarchy: the `id` of the parent/epic plan |
 
 - References are id-pure: the immutable plan `id` only, never titles or filename slugs. Tooling resolves ids to titles at display time.
-- Only the types in use appear as sub-keys. With no relations, the field is the bare key: `relations:` with no value (parses to null).
-- Inverse relations (`blocks`, `superseded_by`, `children`) are derived by tooling, never stored. Each edge is written on the actionable side only.
+- Only the types in use appear as sub-keys. Empty form: the bare key `relations:` with no value.
+- Inverses (`blocks`, `superseded_by`, `children`) are derived by tooling, never stored; each edge is written on the actionable side only.
 - Cycles in `blocked_by` are invalid.
 - `relations` is the only nested frontmatter field: nesting is reserved for open-ended membership; all other fields stay flat scalars.
 
@@ -158,15 +156,12 @@ relations:
 | `fibonacci` (default) | 1, 2, 3, 5, 8, 13, 21 | 13, 21 |
 | `tshirt` | xs, s, m, l, xl | xl |
 
-- Set or confirmed when Phase 1: Definition completes — the moment scope exists. Empty (`""`) before that.
-- Immutable once the plan moves to `doing/` — preserves estimated-vs-actual analysis.
+- Set or confirmed when Phase 1: Definition completes — the moment scope exists; `""` before that.
+- Immutable once the plan is in `doing/`, preserving estimated-vs-actual analysis.
 - A value in the scale's top band signals the plan should be split before execution.
 - The value must belong to the declared scale's token set. Comparability is intra-project.
 
-**`priority`** — `urgent`, `high`, `medium`, `low`, or `""` (no priority).
-
-- Mutable through the plan's whole life.
-- Soft selection signal: among plans not blocked by relations, pick the highest priority first. It complements, never overrides, `blocked_by` gating — a blocked plan is not selectable regardless of priority.
+**`priority`** — `urgent`, `high`, `medium`, `low`, or `""` (no priority). Mutable through the plan's whole life. Soft selection signal: among plans not blocked by relations, pick the highest priority first. It complements, never overrides, `blocked_by` gating — a blocked plan is not selectable regardless of priority.
 
 ### Tracker sync
 
@@ -177,11 +172,11 @@ tracked_in: "https://linear.app/acme/issue/ENG-135"
 ```
 
 - Written by sync tooling on local runs after creating the mirror. `""` means not tracked.
-- Multiple trackers: comma-separated URLs, **one mirror per tracker**. Two mirrors in the same tracker is a signal the plan should be split, not a supported case.
+- Multiple trackers: comma-separated URLs, **one mirror per tracker**. Two mirrors in the same tracker signals the plan should be split, not a supported case.
 - The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field. Sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias: `workplan:<id>`; new mirrors write `plan:<id>` only).
 - `tracked_in` is self-healing: if a stored URL goes stale, the next sync run re-resolves by marker and rewrites it.
-- Source-of-truth split: plan content, state, and dates are owned by the markdown. The tracker's visual organization (projects/initiatives, milestones, tracker-side assignment) is owned by the tracker and never overwritten by sync. A child plan's epic/project derives from the `tracked_in` of its `parent` relation target.
-- Rule 18 is unchanged: inline issue links in prose remain valid; `tracked_in` covers only the plan-level mirror.
+- Source-of-truth split: the markdown owns plan content, state, and dates; the tracker owns its visual organization (projects, milestones, tracker-side assignment), which sync never overwrites. A child plan's epic/project derives from the `tracked_in` of its `parent` target.
+- Rule 18 is unchanged: `tracked_in` covers only the plan-level mirror; inline issue links stay in prose.
 
 ### Sections
 
@@ -213,9 +208,7 @@ Optional subsection at the end of `## Progress`, only for plans with 5+ phases w
 - **C: Templates & migration** — Phases 4, 5
 ```
 
-- Heading is exactly `### Execution sequence`, placed after all phase checklists.
-- Format: `**Letter: Name**` — the name summarizes the block's purpose — followed by its phase(s).
-- Non-invasive: phases keep their numbering and `### Phase N: Name` hierarchy unchanged.
+Heading is exactly `### Execution sequence`, placed after all phase checklists; the block name summarizes the group's purpose. Non-invasive: phases keep their numbering and `### Phase N: Name` hierarchy unchanged.
 
 ### Mandatory phases
 
@@ -251,7 +244,7 @@ The Implementation entries for Phase 1 and Closing use fixed plain-text descript
 
 ### Closing Summary structure
 
-The Closing Summary opens with a mandatory **leader paragraph**. It is the literal export unit: the changelog entry, the mirror's closing comment, and any other projection copy it verbatim — never rewrite it. Its rules are about portability as much as voice; nothing that does not travel outside the repo may appear:
+The Closing Summary opens with a mandatory **leader paragraph** — the literal export unit: changelog entries, mirror closing comments, and any other projection copy it verbatim, never rewrite it. Nothing that does not travel outside the repo may appear:
 
 1. Opens with the result, never the process.
 2. No actor: no people, no models, no team. Impersonal constructions or the deliverable as subject.
@@ -271,9 +264,9 @@ After the leader paragraph, optional subsections group detail under fixed Englis
 | `Deferred` | Work moved out; every item names its destination plan id |
 | `References` | Delivery evidence links (PR, deploy, published doc). One link per bullet, labeled with its evidence kind, absolute URLs only |
 
-Normative status: the leader paragraph is the only unconditionally mandatory element. `References` is conditionally mandatory — present if the work produced verifiable artifacts, omitted when there is no linkable evidence, never left empty. The other four are purely optional. Custom labels are allowed only when no recommended label fits — never a synonym or rename of an existing one — in English and under the same format rules. Total section budget: ~40 lines. Banned: signatures, model attribution in prose, evaluative blocks.
+Normative status: only the leader paragraph is unconditionally mandatory. `References` is conditionally mandatory — present if the work produced verifiable artifacts, omitted when there is no linkable evidence, never left empty. The other four are purely optional. Custom labels are allowed only when no recommended label fits — never a synonym of an existing one — in English, under the same format rules. Total section budget: ~40 lines. Banned: signatures, model attribution in prose, evaluative blocks.
 
-**Extraction contract.** A closed plan guarantees: `id`, `title`, `done_date`, the leader paragraph, and parseable subsections. Derived changelog entries and mirror closing comments copy the leader paragraph verbatim and append the `References` links. The framework does not include a CHANGELOG.md — generation is tooling (a CLI command or a viewer reading plans directly). Pre-existing manual changelogs freeze as legacy for plans with an older format; derivation applies going forward only.
+**Extraction contract.** A closed plan guarantees: `id`, `title`, `done_date`, the leader paragraph, and parseable subsections. Derived changelog entries and mirror closing comments copy the leader paragraph verbatim and append the `References` links. The framework ships no CHANGELOG.md — generation is tooling (a CLI command or a viewer reading plans directly). Pre-existing manual changelogs freeze as legacy for older-format plans; derivation applies going forward only.
 
 ## Rules
 
@@ -330,13 +323,7 @@ Example: `2606455842_user-auth-setup.md` (2026, day 064, 15:30:42).
 
 State transitions never rename. Renaming the description segment is a separate, deliberate action triggered by a `title` change — use `git mv` so blame stays continuous.
 
-**Dot→dash:** any dot inside a number or version identifier in the description must be replaced with a dash to preserve digit boundaries in kebab-case. Examples:
-
-| Case | Wrong (compact) | Right (dot→dash) |
-|------|-----------------|------------------|
-| Version `v0.2.2` | `v022` | `v0-2-2` |
-| Node `18.2` | `node182` | `node-18-2` |
-| Decimal `3.14` | `314` | `3-14` |
+**Dot→dash:** any dot inside a number or version identifier in the description must be replaced with a dash to preserve digit boundaries in kebab-case. Examples: version `v0.2.2` → `v0-2-2` (never `v022`), decimal `3.14` → `3-14`.
 
 ### Timestamp generation
 
@@ -404,9 +391,9 @@ estimate_scale: "fibonacci"
 | `tracker` | No tracker sync |
 | `estimate_scale` | `fibonacci` |
 
-- The root README frontmatter is the only project-level config location. RULES.md frontmatter carries framework metadata only (`name`, `version`).
-- The root `README.md` is user-owned after init: framework updates never modify an existing root README. The state-folder READMEs (`backlog/`, `doing/`, `done/`) remain system files.
-- No `name` constant: the project's machine name derives from the folder/repo, and the human display name is the README's H1. No provider constant: the `tracker` URL's domain selects the sync adapter.
+- The root README frontmatter is the only project-level config location; RULES.md frontmatter carries framework metadata only (`name`, `version`).
+- The root `README.md` is user-owned after init: framework updates never modify an existing root README. The state-folder READMEs remain system files.
+- No `name` constant (the machine name is the folder/repo; the display name is the README's H1) and no provider constant (the `tracker` URL's domain selects the sync adapter).
 
 ## Work destination
 
@@ -428,7 +415,7 @@ Only `"."` or a remote URL are valid — never local paths (they differ across m
 
 When `work_on` is a remote URL, the local path is resolved into `workplans/LOCAL.yml` (auto-generated, gitignored, never committed). When both repos must be configured (plans live in one, code in another), the target repo's agent file (AGENTS.md / CLAUDE.md) must point back to where the plans live. See [README.md](README.md#work-destination) for the full resolution flow.
 
-**Execution conventions.** When the planning repo and the execution repo are separate, the target repo's agent file (AGENTS.md, CLAUDE.md, or equivalent) is the source of truth for execution: git workflow, branch naming, commit and PR format, language. The planning repo's agent file governs only the plan files and the project's purpose. Before committing in the target repo, read and follow its agent file; on conflict, the target repo's conventions prevail for everything execution-related. If the target repo has no agent file, report it and ask the user for conventions instead of assuming the planning repo's.
+**Execution conventions.** When the planning and execution repos are separate, the target repo's agent file (AGENTS.md, CLAUDE.md, or equivalent) is the source of truth for execution: git workflow, branch naming, commit and PR format, language. The planning repo's agent file governs only the plan files. Read the target's agent file before committing there; on conflict, it prevails for everything execution-related. If the target repo has none, report it and ask the user instead of assuming the planning repo's conventions.
 
 ## Extensions
 
@@ -451,7 +438,7 @@ When a plan's declared format is older than the framework `version`, the agent a
 - If the user declines, record the decision for the session and do not ask again.
 - A migrated plan updates its format field to the current version in the same change.
 - Migration alters frontmatter and section order only. Checkboxes, dates, and user content are preserved verbatim.
-- The CLI exposes the same operation as `workplans migrate`, so migration is reproducible rather than agent-improvised.
+- The CLI exposes the same operation as `workplans migrate` for reproducibility.
 
 ### Supported transitions
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -46,17 +46,17 @@ This rule applies to the plan file itself. Execution changes follow their own br
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "backlog"
 author: ""
 author_model: ""
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "YYYY-MM-DDThh:mm"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
 ---
 
 # User authentication setup
@@ -99,28 +99,30 @@ The template is in English as reference only. The `Phase N:` prefix and the five
 
 ### Frontmatter
 
-Frontmatter starts on line 1, no leading blank lines. All fields present; `""` if not applicable.
+Frontmatter starts on line 1, no leading blank lines. All fields present, in the order below; scalar fields empty to `""`.
+
+The field order tells one story: what it is, who, where it stands. `format` goes first — it is the discriminator that says which schema governs the rest of the file.
 
 | Field | Description |
 |-------|-------------|
-| `id` | Timestamp ID matching the filename (`YYDDDsssss`). First field, immutable |
+| `format` | Format the plan follows. At creation, equals `version` in RULES.md. Mutable only on explicit migration. Read-alias: `format_version` (the pre-0.4.0 name; parsers accept both, new plans write `format`) |
+| `id` | Timestamp ID matching the filename (`YYDDDsssss`). Immutable |
 | `title` | Short descriptive title |
-| `state` | Must match the folder: `backlog`, `doing`, `done` |
 | `author` | Human creator. Immutable. Comma-separated if multiple (e.g. `"Alice,Bob"`) |
 | `author_model` | AI model ID(s) that created the plan. See AI model attribution |
 | `assignee` | Person implementing |
 | `assignee_model` | AI model ID(s) that executed the plan |
+| `state` | Must match the folder: `backlog`, `doing`, `done` |
 | `backlog_date` | Datetime created (`YYYY-MM-DDThh:mm`) |
 | `doing_date` | Datetime work started |
 | `done_date` | Datetime completed |
-| `format_version` | Format the plan currently follows. At creation, equals `version` in RULES.md. Mutable only on explicit migration |
 
 ### Sections
 
-Five H2 sections, Title Case. Order depends on `format_version`:
+Five H2 sections, Title Case. Order depends on the plan's declared format:
 
-| `format_version` | Order |
-|------------------|-------|
+| `format` | Order |
+|----------|-------|
 | `0.3.0` or higher (new layout) | `Objective` → `Progress` → `Context` → `Implementation` → `Closing Summary` |
 | `0.2.x` or lower (legacy layout) | `Progress` → `Objective` → `Context` → `Implementation` → `Closing Summary` |
 
@@ -179,8 +181,8 @@ All 27 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 5 | Structure | README files and RULES.md are system files. Do not remove or edit manually |
 | 6 | Structure | Do not add custom frontmatter fields or markdown sections beyond the defined format |
 | 7 | Template | H1 must match the `title` field |
-| 8 | Template | H2 sections must use Title Case. Only 5 valid sections. Section order depends on `format_version` |
-| 9 | Template | Progress phases mirror Implementation phases. Legacy layout (`format_version < 0.3.0`) puts Progress first; new layout (`>= 0.3.0`) puts Objective first |
+| 8 | Template | H2 sections must use Title Case. Only 5 valid sections. Section order depends on the plan's declared format |
+| 9 | Template | Progress phases mirror Implementation phases. Legacy layout (format `< 0.3.0`) puts Progress first; new layout (`>= 0.3.0`) puts Objective first |
 | 10 | Template | Phase 1: Definition is mandatory with three fixed steps. Must not be modified |
 | 11 | Template | Closing phase is mandatory as the last phase with two fixed steps. Must not be modified |
 | 12 | Template | Steps grouped by phase (`### Phase N: Name`), each concrete and verifiable. Use "Phase" and "Step" only (never "Stage") |
@@ -194,7 +196,7 @@ All 27 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 20 | Data | Datetimes must come from the system clock. Hardcoded, estimated, or placeholder values are forbidden |
 | 21 | Data | `author` is immutable once assigned; multiple authors are comma-separated |
 | 22 | Data | `_` separates timestamp ID from description; uniqueness = timestamp + description |
-| 23 | Data | `format_version` reflects the current format. At creation, equals RULES.md `version`. Mutable only on explicit migration; signals which rule set validators apply |
+| 23 | Data | `format` reflects the current format. At creation, equals RULES.md `version`. Mutable only on explicit migration; signals which rule set validators apply. Parsers accept `format_version` as read-alias |
 | 24 | Template | Plan files must not contain emojis. Use plain descriptive text instead |
 | 25 | Template | Steps that cannot be executed by an AI agent (browser checks, external dashboard configuration, manual UI testing, credential rotation) must be prefixed with `[manual]`. The agent skips them and reports to the user; Implementation describes what the user needs to do |
 | 26 | Structure | When the workplans folder is inside a Git repository (or any VCS with branch semantics), the branch for a new plan is decided explicitly before commit: declared policy in agent file → current non-main branch → ask the user. Never default silently to `main`. Outside a VCS, this rule does not apply |

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -156,7 +156,7 @@ References are id-pure — the immutable `id` only, never titles or slugs; tooli
 
 `tracked_in` links a plan to its mirror artifact in an external tracker — issue, task, card, epic: the URL is self-describing (e.g. `"https://linear.app/acme/issue/ENG-135"`). Written by sync tooling on local runs; `""` means not tracked. Multiple trackers: comma-separated URLs, **one mirror per tracker** — two mirrors in the same tracker signals the plan should be split, not a supported case.
 
-The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias `workplan:<id>`; new mirrors write `plan:<id>` only). Write canonical, read liberal: the marker is written as the description's last line, and readers accept it on any line. The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
+The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker. Write canonical, read liberal: the marker is written as the description's last line, and readers accept it on any line. The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
 
 Source-of-truth split: the markdown owns plan content, state, and dates; the tracker owns its visual organization (projects, milestones, tracker-side assignment), which sync never overwrites. A child plan's epic/project derives from the `tracked_in` of its `parent` target. Rule 18 is unchanged: `tracked_in` covers only the plan-level mirror; inline issue links stay in prose.
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -1,6 +1,6 @@
 ---
 name: workplans
-version: 0.3.1
+version: 0.4.0
 ---
 
 # Workplans: Rules

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -204,6 +204,8 @@ Every plan must start with **Phase 1: Definition** (entry gate) and end with a *
 - [ ] Validate implementation with the user
 ```
 
+`Phase N` stands for the plan's actual last phase number — never the literal letter `N`.
+
 The same template applied in Spanish (`Closing Summary` stays in English inside step text because it references the exact H2 section name, which is always English):
 
 ```markdown
@@ -217,7 +219,7 @@ The same template applied in Spanish (`Closing Summary` stays in English inside 
 - [ ] Validar implementación con el usuario
 ```
 
-A plan in `backlog/` with Phase 1 unchecked is still being defined. A plan cannot move to `doing/` until all three steps are checked. A plan cannot move to `done/` until both Closing steps are checked and the user has explicitly approved.
+A plan in `backlog/` with Phase 1 unchecked is still being defined. When the agent defines the objective, context, and phases at creation, it checks the first two Definition steps; `Refine with the user` is checked only after the user validates. A plan cannot move to `doing/` until all three steps are checked. A plan cannot move to `done/` until both Closing steps are checked and the user has explicitly approved.
 
 The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions that also translate to the user's language. English canonical: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` The same entries in Spanish: `Define el Objective, el Context y las fases subsiguientes. Una vez completas, el plan queda listo para ejecución.` and `Valida la implementación con el usuario y escribe el Closing Summary. Una vez completa, el plan queda listo para moverse a done.` Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
 
@@ -233,7 +235,7 @@ The Closing Summary opens with a mandatory **leader paragraph** — the literal 
 6. 3-6 sentences, hard cap.
 7. Litmus test: it must read correctly on a release page with zero context.
 
-After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
+The paragraph and all prose follow the user's language; only the labels below are always English. After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
 
 | Label | Content |
 |-------|---------|

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -49,6 +49,8 @@ This rule applies to the plan file itself. Execution changes follow their own br
 format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
+priority: ""
+estimate: ""
 author: ""
 author_model: ""
 assignee: ""
@@ -109,6 +111,8 @@ The field order tells one story: what it is, who, where it stands. `format` goes
 | `format` | Format the plan follows. At creation, equals `version` in RULES.md. Mutable only on explicit migration. Read-alias: `format_version` (the pre-0.4.0 name; parsers accept both, new plans write `format`) |
 | `id` | Timestamp ID matching the filename (`YYDDDsssss`). Immutable |
 | `title` | Short descriptive title |
+| `priority` | Urgency signal: `urgent`, `high`, `medium`, `low`, or `""` (no priority). Mutable through the plan's whole life. See Triage |
+| `estimate` | Complexity in the project's declared estimate scale. Set when Phase 1: Definition completes; immutable once the plan is in `doing/`. See Triage |
 | `author` | Human creator. Immutable. Comma-separated if multiple (e.g. `"Alice,Bob"`) |
 | `author_model` | AI model ID(s) that created the plan. See AI model attribution |
 | `assignee` | Person implementing |
@@ -141,6 +145,27 @@ relations:
 - Inverse relations (`blocks`, `superseded_by`, `children`) are derived by tooling, never stored. Each edge is written on the actionable side only.
 - Cycles in `blocked_by` are invalid.
 - `relations` is the only nested frontmatter field: nesting is reserved for open-ended membership; all other fields stay flat scalars.
+
+### Triage
+
+`estimate` and `priority` dimension and order plans.
+
+**`estimate`** — complexity in the scale declared by the project's `estimate_scale` constant (see Project constants). Presets:
+
+| Scale | Tokens | Split signal (top band) |
+|-------|--------|-------------------------|
+| `fibonacci` (default) | 1, 2, 3, 5, 8, 13, 21 | 13, 21 |
+| `tshirt` | xs, s, m, l, xl | xl |
+
+- Set or confirmed when Phase 1: Definition completes — the moment scope exists. Empty (`""`) before that.
+- Immutable once the plan moves to `doing/` — preserves estimated-vs-actual analysis.
+- A value in the scale's top band signals the plan should be split before execution.
+- The value must belong to the declared scale's token set. Comparability is intra-project.
+
+**`priority`** — `urgent`, `high`, `medium`, `low`, or `""` (no priority).
+
+- Mutable through the plan's whole life.
+- Soft selection signal: among plans not blocked by relations, pick the highest priority first. It complements, never overrides, `blocked_by` gating — a blocked plan is not selectable regardless of priority.
 
 ### Sections
 
@@ -195,7 +220,7 @@ The Implementation entries for Phase 1 and Closing use fixed plain-text descript
 
 ## Rules
 
-All 29 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 31 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -228,6 +253,8 @@ All 29 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language. Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
 | 28 | Data | `relations` sub-keys are limited to `blocked_by`, `relates_to`, `supersedes`, `parent`. Targets are immutable plan `id`s, comma-separated; no titles or slugs |
 | 29 | Template | A plan with a non-empty `blocked_by` must not move to `doing/` until every referenced plan is `done`. Cycles in `blocked_by` are invalid |
+| 30 | Data | `estimate` is set when Phase 1: Definition completes, must belong to the declared `estimate_scale` token set, and is immutable once the plan is in `doing/` |
+| 31 | Data | `priority` is one of `urgent`, `high`, `medium`, `low`, `""`. Mutable; a plan blocked by relations is not selectable regardless of priority |
 
 ## File naming
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -436,4 +436,26 @@ Optional extensions live in `workplans/extend/`, one subfolder per extension. Th
 
 ## Compatibility
 
-The `version` field declares the active framework version. Plans declare their own `format_version`; validators apply the rule set matching that value, so plans from different framework versions coexist. Plans without `format_version` are implicitly pre-0.2.1 (legacy layout, Progress first).
+The `version` field declares the active framework version. Plans declare their own `format` (or `format_version`, its pre-0.4.0 name — parsers accept both); validators apply the rule set matching that value, so plans from different framework versions coexist. Plans without either field are implicitly pre-0.2.1 (legacy layout, Progress first).
+
+### Migration
+
+When a plan's declared format is older than the framework `version`, the agent asks the user whether to migrate it — never silently:
+
+| Folder | Migration |
+|--------|-----------|
+| `backlog/` | Offered by default |
+| `doing/` | Only on explicit user request |
+| `done/` | Never — historical record, immutable with its original format |
+
+- If the user declines, record the decision for the session and do not ask again.
+- A migrated plan updates its format field to the current version in the same change.
+- Migration alters frontmatter and section order only. Checkboxes, dates, and user content are preserved verbatim.
+- The CLI exposes the same operation as `workplans migrate`, so migration is reproducible rather than agent-improvised.
+
+### Supported transitions
+
+| From | To | Transformation |
+|------|----|----------------|
+| pre-0.2.1, 0.2.x | 0.3.0 | Reorder the five H2 sections to the new layout (Objective first); set `format_version: "0.3.0"` |
+| 0.3.x | 0.4.0 | Rename `format_version` to `format` and move it first; reorder fields to the 0.4.0 order; add `priority`, `estimate`, `tracked_in` as `""` and the bare `relations:` key |

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -156,7 +156,7 @@ References are id-pure — the immutable `id` only, never titles or slugs; tooli
 
 `tracked_in` links a plan to its mirror artifact in an external tracker — issue, task, card, epic: the URL is self-describing (e.g. `"https://linear.app/acme/issue/ENG-135"`). Written by sync tooling on local runs; `""` means not tracked. Multiple trackers: comma-separated URLs, **one mirror per tracker** — two mirrors in the same tracker signals the plan should be split, not a supported case.
 
-The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias `workplan:<id>`; new mirrors write `plan:<id>` only). The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
+The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias `workplan:<id>`; new mirrors write `plan:<id>` only). Write canonical, read liberal: the marker is written as the description's last line, and readers accept it on any line. The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
 
 Source-of-truth split: the markdown owns plan content, state, and dates; the tracker owns its visual organization (projects, milestones, tracker-side assignment), which sync never overwrites. A child plan's epic/project derives from the `tracked_in` of its `parent` target. Rule 18 is unchanged: `tracked_in` covers only the plan-level mirror; inline issue links stay in prose.
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -1,7 +1,6 @@
 ---
 name: workplans
 version: 0.3.1
-work_on: "."
 ---
 
 # Workplans: Rules
@@ -35,7 +34,7 @@ State transitions move the file and update frontmatter; they never rename. The f
 
 The branch a plan is committed on is an explicit decision, not a side-effect of the current shell state. Resolve in order, stop at the first match. The VCS check (step 2) only fires when no policy is declared — a declared policy implies a VCS is present, so no further verification is needed:
 
-1. **Policy declared** in the agent file (AGENTS.md, CLAUDE.md, etc.) → follow it.
+1. **Policy declared** in the agent file (AGENTS.md, CLAUDE.md, etc.) → follow it. A planning-only repo may declare a main-only policy (e.g. "all plans commit directly to main; no feature branches for plan files"), which keeps every plan visible on the main branch.
 2. **No VCS detected** (`git rev-parse --is-inside-work-tree` does not return `true`) → write the plan to disk, no branch question.
 3. **VCS + current branch is not the main branch** → commit on the current branch.
 4. **VCS + current branch is main** → ask the user whether to create a new branch first or commit on main.
@@ -278,7 +277,7 @@ Normative status: the leader paragraph is the only unconditionally mandatory ele
 
 ## Rules
 
-All 33 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 34 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -286,7 +285,7 @@ All 33 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 2 | Structure | The timestamp portion of the filename and the matching `id` are immutable. The description portion of the filename is mutable when `title` changes substantially — see File naming |
 | 3 | Structure | `workplans/` only contains structured plan files. No notes, docs, or unstructured content |
 | 4 | Structure | Do not create files or folders that alter the `workplans/` structure |
-| 5 | Structure | README files and RULES.md are system files. Do not remove or edit manually |
+| 5 | Structure | RULES.md and the state-folder READMEs are system files: do not remove or edit manually. The root README.md is user-owned after init and carries the project constants |
 | 6 | Structure | Do not add custom frontmatter fields or markdown sections beyond the defined format |
 | 7 | Template | H1 must match the `title` field |
 | 8 | Template | H2 sections must use Title Case. Only 5 valid sections. Section order depends on the plan's declared format |
@@ -315,6 +314,7 @@ All 33 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 31 | Data | `priority` is one of `urgent`, `high`, `medium`, `low`, `""`. Mutable; a plan blocked by relations is not selectable regardless of priority |
 | 32 | Data | `tracked_in` holds the mirror URL(s), one mirror per tracker, comma-separated. Written by sync tooling; agents do not edit it manually |
 | 33 | Template | The Closing Summary of a done plan opens with the leader paragraph; subsection grouping uses the recommended vocabulary; exports copy the paragraph verbatim — see Closing Summary structure |
+| 34 | Structure | Subfolders inside `workplans/` (beyond the state folders and `extend/`) are invalid. One repo, one project — a multi-project layout is not part of this version |
 
 ## File naming
 
@@ -386,13 +386,35 @@ The client suffix is omitted when the agent runs directly (API, Claude Code, web
 - **User-authored content** (title, descriptions, steps, summary) follows the user's active conversation language.
 - **Orthography** must be preserved: accents, ñ, and other special characters of the user's language. UTF-8 is the encoding for Markdown files.
 
+## Project constants
+
+The frontmatter of the root `workplans/README.md` carries the project constants. All are optional with defaults; in the common case the frontmatter does not exist at all — it appears the first time there is something to declare:
+
+```yaml
+---
+work_on: "https://github.com/acme/backend"
+tracker: "https://linear.app/acme/team/ENG"
+estimate_scale: "fibonacci"
+---
+```
+
+| Constant | Absent means |
+|----------|--------------|
+| `work_on` | Plans target this same repo (equivalent to `"."`) |
+| `tracker` | No tracker sync |
+| `estimate_scale` | `fibonacci` |
+
+- The root README frontmatter is the only project-level config location. RULES.md frontmatter carries framework metadata only (`name`, `version`).
+- The root `README.md` is user-owned after init: framework updates never modify an existing root README. The state-folder READMEs (`backlog/`, `doing/`, `done/`) remain system files.
+- No `name` constant: the project's machine name derives from the folder/repo, and the human display name is the README's H1. No provider constant: the `tracker` URL's domain selects the sync adapter.
+
 ## Work destination
 
-The `work_on` field in RULES.md frontmatter declares where plan execution applies. Valid values:
+The `work_on` constant declares where plan execution applies. Valid values:
 
 | Value | Meaning |
 |-------|---------|
-| `"."` (default) | Parent directory of `workplans/`. Plans target the same project |
+| `"."` or absent (default) | Parent directory of `workplans/`. Plans target the same project |
 | Remote URL | Plans target a different project (e.g. `https://github.com/org/project`) |
 
 Two destinations for changes:
@@ -402,9 +424,11 @@ Two destinations for changes:
 | Plan files (Markdown, frontmatter, folder moves) | Inside `workplans/` |
 | Plan execution (code, configs, assets) | At `work_on` |
 
-Only `"."` or a remote URL are valid in RULES.md — never local paths (they differ across machines).
+Only `"."` or a remote URL are valid — never local paths (they differ across machines).
 
 When `work_on` is a remote URL, the local path is resolved into `workplans/LOCAL.yml` (auto-generated, gitignored, never committed). When both repos must be configured (plans live in one, code in another), the target repo's agent file (AGENTS.md / CLAUDE.md) must point back to where the plans live. See [README.md](README.md#work-destination) for the full resolution flow.
+
+**Execution conventions.** When the planning repo and the execution repo are separate, the target repo's agent file (AGENTS.md, CLAUDE.md, or equivalent) is the source of truth for execution: git workflow, branch naming, commit and PR format, language. The planning repo's agent file governs only the plan files and the project's purpose. Before committing in the target repo, read and follow its agent file; on conflict, the target repo's conventions prevail for everything execution-related. If the target repo has no agent file, report it and ask the user for conventions instead of assuming the planning repo's.
 
 ## Extensions
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -233,9 +233,10 @@ The Closing Summary opens with a mandatory **leader paragraph** — the literal 
 4. No temporal deictics ("today", "this week").
 5. No links — pointers live in `References`.
 6. 3-6 sentences, hard cap.
-7. Litmus test: it must read correctly on a release page with zero context.
+7. In the user's language, like all plan prose — only the subsection labels are English.
+8. Litmus test: it must read correctly, in the user's language, on a release page with zero context.
 
-The paragraph and all prose follow the user's language; only the labels below are always English. After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
+After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
 
 | Label | Content |
 |-------|---------|

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -199,7 +199,7 @@ Five H2 sections, Title Case. Order depends on the plan's declared format:
 | `## Progress` | Checklist mirror of Implementation phases |
 | `## Context` | Background, constraints, or references |
 | `## Implementation` | Technical detail organized by phase |
-| `## Closing Summary` | Bullet points written when the last phase is completed. Until then: `_To be written when the last phase is completed._` |
+| `## Closing Summary` | Leader paragraph plus optional labeled subsections, written when the last phase is completed (see Closing Summary structure). Until then: `_To be written when the last phase is completed._` |
 
 H1 is the first line after the frontmatter and must match `title` exactly. One H1 per file.
 
@@ -235,9 +235,35 @@ A plan in `backlog/` with Phase 1 unchecked is still being defined. A plan canno
 
 The Implementation entries for Phase 1 and Closing use fixed plain-text descriptions that also translate to the user's language. English canonical: `Define the Objective, Context, and subsequent phases. Once complete, the plan is ready for execution.` and `Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.` The same entries in Spanish: `Define el Objective, el Context y las fases subsiguientes. Una vez completas, el plan queda listo para ejecución.` and `Valida la implementación con el usuario y escribe el Closing Summary. Una vez completa, el plan queda listo para moverse a done.` Italic in plan files is reserved for temporary placeholders (e.g. `_To be written when the last phase is completed._`).
 
+### Closing Summary structure
+
+The Closing Summary opens with a mandatory **leader paragraph**. It is the literal export unit: the changelog entry, the mirror's closing comment, and any other projection copy it verbatim — never rewrite it. Its rules are about portability as much as voice; nothing that does not travel outside the repo may appear:
+
+1. Opens with the result, never the process.
+2. No actor: no people, no models, no team. Impersonal constructions or the deliverable as subject.
+3. No references that do not travel: phase numbers, plan ids, repo-internal paths.
+4. No temporal deictics ("today", "this week").
+5. No links: the paragraph is pure narrative; pointers live in `References`.
+6. 3-6 sentences, hard cap.
+7. Litmus test: it must read correctly on a release page with zero context.
+
+After the leader paragraph, optional subsections group detail under fixed English H3 labels — the recommended, non-exclusive vocabulary. If you group, use these names:
+
+| Label | Content |
+|-------|---------|
+| `Delivered` | What shipped, one item per bullet |
+| `Decisions` | Decisions taken and deviations from the plan |
+| `Verification` | How the result was verified |
+| `Deferred` | Work moved out; every item names its destination plan id |
+| `References` | Delivery evidence links (PR, deploy, published doc). One link per bullet, labeled with its evidence kind, absolute URLs only |
+
+Normative status: the leader paragraph is the only unconditionally mandatory element. `References` is conditionally mandatory — present if the work produced verifiable artifacts, omitted when there is no linkable evidence, never left empty. The other four are purely optional. Custom labels are allowed only when no recommended label fits — never a synonym or rename of an existing one — in English and under the same format rules. Total section budget: ~40 lines. Banned: signatures, model attribution in prose, evaluative blocks.
+
+**Extraction contract.** A closed plan guarantees: `id`, `title`, `done_date`, the leader paragraph, and parseable subsections. Derived changelog entries and mirror closing comments copy the leader paragraph verbatim and append the `References` links. The framework does not include a CHANGELOG.md — generation is tooling (a CLI command or a viewer reading plans directly). Pre-existing manual changelogs freeze as legacy for plans with an older format; derivation applies going forward only.
+
 ## Rules
 
-All 32 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 33 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -273,6 +299,7 @@ All 32 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 30 | Data | `estimate` is set when Phase 1: Definition completes, must belong to the declared `estimate_scale` token set, and is immutable once the plan is in `doing/` |
 | 31 | Data | `priority` is one of `urgent`, `high`, `medium`, `low`, `""`. Mutable; a plan blocked by relations is not selectable regardless of priority |
 | 32 | Data | `tracked_in` holds the mirror URL(s), one mirror per tracker, comma-separated. Written by sync tooling; agents do not edit it manually |
+| 33 | Template | The Closing Summary of a done plan opens with the leader paragraph; subsection grouping uses the recommended vocabulary; exports copy the paragraph verbatim — see Closing Summary structure |
 
 ## File naming
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -203,6 +203,21 @@ Five H2 sections, Title Case. Order depends on the plan's declared format:
 
 H1 is the first line after the frontmatter and must match `title` exactly. One H1 per file.
 
+### Execution sequence
+
+Optional subsection at the end of `## Progress`, only for plans with 5+ phases where grouping adds value. It groups related phases into lettered blocks indicating what to execute together and in what order:
+
+```markdown
+### Execution sequence
+- **A: Infrastructure** — Phase 1
+- **B: Base components** — Phases 2, 3
+- **C: Templates & migration** — Phases 4, 5
+```
+
+- Heading is exactly `### Execution sequence`, placed after all phase checklists.
+- Format: `**Letter: Name**` — the name summarizes the block's purpose — followed by its phase(s).
+- Non-invasive: phases keep their numbering and `### Phase N: Name` hierarchy unchanged.
+
 ### Mandatory phases
 
 Every plan must start with **Phase 1: Definition** (entry gate) and end with a **Closing** phase (exit gate). The structure, action, and order of steps in both are fixed — but the phase name and step text translate to the user's active conversation language (only the `Phase N:` prefix and the H2 headings remain English):

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -59,6 +59,7 @@ state: "backlog"
 backlog_date: "YYYY-MM-DDThh:mm"
 doing_date: ""
 done_date: ""
+tracked_in: ""
 relations:
 ---
 
@@ -121,6 +122,7 @@ The field order tells one story: what it is, who, where it stands. `format` goes
 | `backlog_date` | Datetime created (`YYYY-MM-DDThh:mm`) |
 | `doing_date` | Datetime work started |
 | `done_date` | Datetime completed |
+| `tracked_in` | URL(s) of the plan's mirror artifact in external tracker(s). Written by sync tooling; `""` = not tracked. See Tracker sync |
 | `relations` | Typed relations to other plans. Nested map; empties to the bare key (`relations:` with no value). See Relations |
 
 ### Relations
@@ -166,6 +168,21 @@ relations:
 
 - Mutable through the plan's whole life.
 - Soft selection signal: among plans not blocked by relations, pick the highest priority first. It complements, never overrides, `blocked_by` gating — a blocked plan is not selectable regardless of priority.
+
+### Tracker sync
+
+`tracked_in` links a plan to its mirror artifact in an external tracker (issue, task, card, epic — the URL is self-describing: the domain identifies the provider, the path the artifact kind).
+
+```yaml
+tracked_in: "https://linear.app/acme/issue/ENG-135"
+```
+
+- Written by sync tooling on local runs after creating the mirror. `""` means not tracked.
+- Multiple trackers: comma-separated URLs, **one mirror per tracker**. Two mirrors in the same tracker is a signal the plan should be split, not a supported case.
+- The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field. Sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias: `workplan:<id>`; new mirrors write `plan:<id>` only).
+- `tracked_in` is self-healing: if a stored URL goes stale, the next sync run re-resolves by marker and rewrites it.
+- Source-of-truth split: plan content, state, and dates are owned by the markdown. The tracker's visual organization (projects/initiatives, milestones, tracker-side assignment) is owned by the tracker and never overwritten by sync. A child plan's epic/project derives from the `tracked_in` of its `parent` relation target.
+- Rule 18 is unchanged: inline issue links in prose remain valid; `tracked_in` covers only the plan-level mirror.
 
 ### Sections
 
@@ -220,7 +237,7 @@ The Implementation entries for Phase 1 and Closing use fixed plain-text descript
 
 ## Rules
 
-All 31 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
+All 32 rules are mandatory. Ordered by criticality: **Structure** (framework integrity) → **Template** (plan validity) → **Data** (field correctness).
 
 | # | Category | Rule |
 |---|----------|------|
@@ -255,6 +272,7 @@ All 31 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 29 | Template | A plan with a non-empty `blocked_by` must not move to `doing/` until every referenced plan is `done`. Cycles in `blocked_by` are invalid |
 | 30 | Data | `estimate` is set when Phase 1: Definition completes, must belong to the declared `estimate_scale` token set, and is immutable once the plan is in `doing/` |
 | 31 | Data | `priority` is one of `urgent`, `high`, `medium`, `low`, `""`. Mutable; a plan blocked by relations is not selectable regardless of priority |
+| 32 | Data | `tracked_in` holds the mirror URL(s), one mirror per tracker, comma-separated. Written by sync tooling; agents do not edit it manually |
 
 ## File naming
 

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -106,11 +106,11 @@ Frontmatter starts on line 1, no leading blank lines. All fields present, in the
 
 | Field | Description |
 |-------|-------------|
-| `format` | Format the plan follows; the discriminator that says which schema governs the rest of the file, hence first. At creation, equals `version` in RULES.md. Read-alias: `format_version` (pre-0.4.0 name) |
+| `format` | The schema discriminator, hence first. At creation, equals `version` in RULES.md. Read-alias: `format_version` (pre-0.4.0 name) |
 | `id` | Timestamp ID matching the filename (`YYDDDsssss`). Immutable |
 | `title` | Short descriptive title |
-| `priority` | Urgency: `urgent`, `high`, `medium`, `low`, or `""`. Mutable for life. See Triage |
-| `estimate` | Complexity in the project's declared scale. Set when Phase 1 completes; immutable in `doing/`. See Triage |
+| `priority` | Urgency signal; mutable. See Triage |
+| `estimate` | Complexity in the project's declared scale; immutable in `doing/`. See Triage |
 | `author` | Human creator. Immutable. Comma-separated if multiple (e.g. `"Alice,Bob"`) |
 | `author_model` | AI model ID(s) that created the plan. See AI model attribution |
 | `assignee` | Person implementing |
@@ -119,8 +119,8 @@ Frontmatter starts on line 1, no leading blank lines. All fields present, in the
 | `backlog_date` | Datetime created (`YYYY-MM-DDThh:mm`) |
 | `doing_date` | Datetime work started |
 | `done_date` | Datetime completed |
-| `tracked_in` | Mirror URL(s) in external tracker(s), written by sync tooling; `""` = not tracked. See Tracker sync |
-| `relations` | Typed relations to other plans. Nested map; empties to the bare key (`relations:` with no value). See Relations |
+| `tracked_in` | Mirror URL(s) in external tracker(s); `""` = not tracked. See Tracker sync |
+| `relations` | Typed relations to other plans; bare key when empty. See Relations |
 
 ### Relations
 
@@ -134,49 +134,31 @@ relations:
 
 | Type | Meaning |
 |------|---------|
-| `blocked_by` | Hard dependency: every referenced plan must be `done` before this plan moves to `doing` |
+| `blocked_by` | Hard dependency: every referenced plan must be `done` before this plan moves to `doing`. Cycles are invalid |
 | `relates_to` | Soft, non-blocking association |
 | `supersedes` | This plan replaces the referenced plan(s) |
 | `parent` | Hierarchy: the `id` of the parent/epic plan |
 
-- References are id-pure: the immutable plan `id` only, never titles or filename slugs. Tooling resolves ids to titles at display time.
-- Only the types in use appear as sub-keys. Empty form: the bare key `relations:` with no value.
-- Inverses (`blocks`, `superseded_by`, `children`) are derived by tooling, never stored; each edge is written on the actionable side only.
-- Cycles in `blocked_by` are invalid.
-- `relations` is the only nested frontmatter field: nesting is reserved for open-ended membership; all other fields stay flat scalars.
+References are id-pure — the immutable `id` only, never titles or slugs; tooling resolves ids to titles at display time. Only the types in use appear as sub-keys; the empty form is the bare key `relations:` with no value. Inverses (`blocks`, `superseded_by`, `children`) are derived, never stored — each edge is written on the actionable side only. `relations` is the only nested field: nesting is reserved for open-ended membership, all other fields stay flat scalars.
 
 ### Triage
 
-`estimate` and `priority` dimension and order plans.
-
-**`estimate`** — complexity in the scale declared by the project's `estimate_scale` constant (see Project constants). Presets:
+**`estimate`** — complexity in the scale declared by the project's `estimate_scale` constant (see Project constants); the value must belong to the scale's token set. Set or confirmed when Phase 1: Definition completes (`""` before that); immutable once the plan is in `doing/`. A top-band value signals the plan should be split before execution. Comparability is intra-project. Presets:
 
 | Scale | Tokens | Split signal (top band) |
 |-------|--------|-------------------------|
 | `fibonacci` (default) | 1, 2, 3, 5, 8, 13, 21 | 13, 21 |
 | `tshirt` | xs, s, m, l, xl | xl |
 
-- Set or confirmed when Phase 1: Definition completes — the moment scope exists; `""` before that.
-- Immutable once the plan is in `doing/`, preserving estimated-vs-actual analysis.
-- A value in the scale's top band signals the plan should be split before execution.
-- The value must belong to the declared scale's token set. Comparability is intra-project.
-
 **`priority`** — `urgent`, `high`, `medium`, `low`, or `""` (no priority). Mutable through the plan's whole life. Soft selection signal: among plans not blocked by relations, pick the highest priority first. It complements, never overrides, `blocked_by` gating — a blocked plan is not selectable regardless of priority.
 
 ### Tracker sync
 
-`tracked_in` links a plan to its mirror artifact in an external tracker (issue, task, card, epic — the URL is self-describing: the domain identifies the provider, the path the artifact kind).
+`tracked_in` links a plan to its mirror artifact in an external tracker — issue, task, card, epic: the URL is self-describing (e.g. `"https://linear.app/acme/issue/ENG-135"`). Written by sync tooling on local runs; `""` means not tracked. Multiple trackers: comma-separated URLs, **one mirror per tracker** — two mirrors in the same tracker signals the plan should be split, not a supported case.
 
-```yaml
-tracked_in: "https://linear.app/acme/issue/ENG-135"
-```
+The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field: sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias `workplan:<id>`; new mirrors write `plan:<id>` only). The field is self-healing — a stale URL is re-resolved by marker and rewritten on the next run.
 
-- Written by sync tooling on local runs after creating the mirror. `""` means not tracked.
-- Multiple trackers: comma-separated URLs, **one mirror per tracker**. Two mirrors in the same tracker signals the plan should be split, not a supported case.
-- The sync idempotency key is the marker **`plan:<id>`** in the mirror's description, not this field. Sync tooling must tolerate an empty `tracked_in` and resolve by marker (read-alias: `workplan:<id>`; new mirrors write `plan:<id>` only).
-- `tracked_in` is self-healing: if a stored URL goes stale, the next sync run re-resolves by marker and rewrites it.
-- Source-of-truth split: the markdown owns plan content, state, and dates; the tracker owns its visual organization (projects, milestones, tracker-side assignment), which sync never overwrites. A child plan's epic/project derives from the `tracked_in` of its `parent` target.
-- Rule 18 is unchanged: `tracked_in` covers only the plan-level mirror; inline issue links stay in prose.
+Source-of-truth split: the markdown owns plan content, state, and dates; the tracker owns its visual organization (projects, milestones, tracker-side assignment), which sync never overwrites. A child plan's epic/project derives from the `tracked_in` of its `parent` target. Rule 18 is unchanged: `tracked_in` covers only the plan-level mirror; inline issue links stay in prose.
 
 ### Sections
 
@@ -193,22 +175,19 @@ Five H2 sections, Title Case. Order depends on the plan's declared format:
 | `## Progress` | Checklist mirror of Implementation phases |
 | `## Context` | Background, constraints, or references |
 | `## Implementation` | Technical detail organized by phase |
-| `## Closing Summary` | Leader paragraph plus optional labeled subsections, written when the last phase is completed (see Closing Summary structure). Until then: `_To be written when the last phase is completed._` |
+| `## Closing Summary` | Leader paragraph plus optional labeled subsections (see Closing Summary structure). Until then: `_To be written when the last phase is completed._` |
 
 H1 is the first line after the frontmatter and must match `title` exactly. One H1 per file.
 
 ### Execution sequence
 
-Optional subsection at the end of `## Progress`, only for plans with 5+ phases where grouping adds value. It groups related phases into lettered blocks indicating what to execute together and in what order:
+Optional subsection at the end of `## Progress` (after all phase checklists), only for plans with 5+ phases where grouping adds value: lettered blocks naming what to execute together and in what order. Non-invasive — phases keep their numbering and `### Phase N: Name` hierarchy unchanged.
 
 ```markdown
 ### Execution sequence
 - **A: Infrastructure** — Phase 1
 - **B: Base components** — Phases 2, 3
-- **C: Templates & migration** — Phases 4, 5
 ```
-
-Heading is exactly `### Execution sequence`, placed after all phase checklists; the block name summarizes the group's purpose. Non-invasive: phases keep their numbering and `### Phase N: Name` hierarchy unchanged.
 
 ### Mandatory phases
 
@@ -247,26 +226,26 @@ The Implementation entries for Phase 1 and Closing use fixed plain-text descript
 The Closing Summary opens with a mandatory **leader paragraph** — the literal export unit: changelog entries, mirror closing comments, and any other projection copy it verbatim, never rewrite it. Nothing that does not travel outside the repo may appear:
 
 1. Opens with the result, never the process.
-2. No actor: no people, no models, no team. Impersonal constructions or the deliverable as subject.
+2. No actor — no people, models, or team: impersonal constructions or the deliverable as subject.
 3. No references that do not travel: phase numbers, plan ids, repo-internal paths.
 4. No temporal deictics ("today", "this week").
-5. No links: the paragraph is pure narrative; pointers live in `References`.
+5. No links — pointers live in `References`.
 6. 3-6 sentences, hard cap.
 7. Litmus test: it must read correctly on a release page with zero context.
 
-After the leader paragraph, optional subsections group detail under fixed English H3 labels — the recommended, non-exclusive vocabulary. If you group, use these names:
+After the leader paragraph, optional subsections group detail under fixed English H3 labels, one item per bullet. If you group, use these names:
 
 | Label | Content |
 |-------|---------|
-| `Delivered` | What shipped, one item per bullet |
+| `Delivered` | What shipped |
 | `Decisions` | Decisions taken and deviations from the plan |
 | `Verification` | How the result was verified |
 | `Deferred` | Work moved out; every item names its destination plan id |
-| `References` | Delivery evidence links (PR, deploy, published doc). One link per bullet, labeled with its evidence kind, absolute URLs only |
+| `References` | Delivery evidence links (PR, deploy, published doc), one per bullet, labeled, absolute URLs only |
 
-Normative status: only the leader paragraph is unconditionally mandatory. `References` is conditionally mandatory — present if the work produced verifiable artifacts, omitted when there is no linkable evidence, never left empty. The other four are purely optional. Custom labels are allowed only when no recommended label fits — never a synonym of an existing one — in English, under the same format rules. Total section budget: ~40 lines. Banned: signatures, model attribution in prose, evaluative blocks.
+Only the leader paragraph is unconditionally mandatory. `References` is conditionally mandatory — present if the work produced verifiable artifacts, omitted when there is no linkable evidence, never left empty. The other four are purely optional. Custom labels only when no recommended label fits — never a synonym of an existing one — in English, under the same rules. Total budget: ~40 lines. Banned: signatures, model attribution in prose, evaluative blocks.
 
-**Extraction contract.** A closed plan guarantees: `id`, `title`, `done_date`, the leader paragraph, and parseable subsections. Derived changelog entries and mirror closing comments copy the leader paragraph verbatim and append the `References` links. The framework ships no CHANGELOG.md — generation is tooling (a CLI command or a viewer reading plans directly). Pre-existing manual changelogs freeze as legacy for older-format plans; derivation applies going forward only.
+**Extraction contract.** A closed plan guarantees: `id`, `title`, `done_date`, the leader paragraph, and parseable subsections. Derived changelog entries and mirror closing comments copy the leader paragraph verbatim and append the `References` links. The framework ships no CHANGELOG.md — generation is tooling. Pre-existing manual changelogs freeze as legacy for older-format plans; derivation applies going forward only.
 
 ## Rules
 
@@ -296,18 +275,18 @@ All 34 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 20 | Data | Datetimes must come from the system clock. Hardcoded, estimated, or placeholder values are forbidden |
 | 21 | Data | `author` is immutable once assigned; multiple authors are comma-separated |
 | 22 | Data | `_` separates timestamp ID from description; uniqueness = timestamp + description |
-| 23 | Data | `format` reflects the current format. At creation, equals RULES.md `version`. Mutable only on explicit migration; signals which rule set validators apply. Parsers accept `format_version` as read-alias |
+| 23 | Data | `format` reflects the current format. At creation, equals RULES.md `version`. Mutable only on explicit migration; signals which rule set validators apply |
 | 24 | Template | Plan files must not contain emojis. Use plain descriptive text instead |
 | 25 | Template | Steps that cannot be executed by an AI agent (browser checks, external dashboard configuration, manual UI testing, credential rotation) must be prefixed with `[manual]`. The agent skips them and reports to the user; Implementation describes what the user needs to do |
 | 26 | Structure | When the workplans folder is inside a Git repository (or any VCS with branch semantics), the branch for a new plan is decided explicitly before commit: declared policy in agent file → current non-main branch → ask the user. Never default silently to `main`. Outside a VCS, this rule does not apply |
 | 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language, preserving full orthography (accents, diacritics). Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
 | 28 | Data | `relations` sub-keys are limited to `blocked_by`, `relates_to`, `supersedes`, `parent`. Targets are immutable plan `id`s, comma-separated; no titles or slugs |
-| 29 | Template | A plan with a non-empty `blocked_by` must not move to `doing/` until every referenced plan is `done`. Cycles in `blocked_by` are invalid |
-| 30 | Data | `estimate` is set when Phase 1: Definition completes, must belong to the declared `estimate_scale` token set, and is immutable once the plan is in `doing/` |
-| 31 | Data | `priority` is one of `urgent`, `high`, `medium`, `low`, `""`. Mutable; a plan blocked by relations is not selectable regardless of priority |
-| 32 | Data | `tracked_in` holds the mirror URL(s), one mirror per tracker, comma-separated. Written by sync tooling; agents do not edit it manually |
-| 33 | Template | The Closing Summary of a done plan opens with the leader paragraph; subsection grouping uses the recommended vocabulary; exports copy the paragraph verbatim — see Closing Summary structure |
-| 34 | Structure | Subfolders inside `workplans/` (beyond the state folders and `extend/`) are invalid. One repo, one project — a multi-project layout is not part of this version |
+| 29 | Template | A plan with a non-empty `blocked_by` must not move to `doing/` until every referenced plan is `done`. Cycles are invalid |
+| 30 | Data | `estimate` is set when Phase 1: Definition completes, must belong to the declared scale's token set, and is immutable once in `doing/` |
+| 31 | Data | `priority` is `urgent`, `high`, `medium`, `low`, or `""`. Mutable; a blocked plan is not selectable regardless of priority |
+| 32 | Data | `tracked_in` holds the mirror URL(s), one per tracker, comma-separated. Written by sync tooling, not edited manually |
+| 33 | Template | A done plan's Closing Summary opens with the leader paragraph and groups detail only under the recommended vocabulary — see Closing Summary structure |
+| 34 | Structure | Subfolders inside `workplans/` beyond the state folders and `extend/` are invalid — single-project layout only in this version |
 
 ## File naming
 
@@ -375,7 +354,7 @@ The client suffix is omitted when the agent runs directly (API, Claude Code, web
 
 ## Project constants
 
-The frontmatter of the root `workplans/README.md` carries the project constants. All are optional with defaults; in the common case the frontmatter does not exist at all — it appears the first time there is something to declare:
+The frontmatter of the root `workplans/README.md` is the only project-level config location; RULES.md frontmatter carries framework metadata only (`name`, `version`). All constants are optional with defaults — in the common case the frontmatter does not exist at all, appearing the first time there is something to declare:
 
 ```yaml
 ---
@@ -391,9 +370,7 @@ estimate_scale: "fibonacci"
 | `tracker` | No tracker sync |
 | `estimate_scale` | `fibonacci` |
 
-- The root README frontmatter is the only project-level config location; RULES.md frontmatter carries framework metadata only (`name`, `version`).
-- The root `README.md` is user-owned after init: framework updates never modify an existing root README. The state-folder READMEs remain system files.
-- No `name` constant (the machine name is the folder/repo; the display name is the README's H1) and no provider constant (the `tracker` URL's domain selects the sync adapter).
+The root `README.md` is user-owned after init: framework updates never modify an existing root README (state-folder READMEs remain system files). There is no `name` constant (machine name = folder/repo; display name = the README's H1) and no provider constant (the `tracker` URL's domain selects the sync adapter).
 
 ## Work destination
 
@@ -415,7 +392,7 @@ Only `"."` or a remote URL are valid — never local paths (they differ across m
 
 When `work_on` is a remote URL, the local path is resolved into `workplans/LOCAL.yml` (auto-generated, gitignored, never committed). When both repos must be configured (plans live in one, code in another), the target repo's agent file (AGENTS.md / CLAUDE.md) must point back to where the plans live. See [README.md](README.md#work-destination) for the full resolution flow.
 
-**Execution conventions.** When the planning and execution repos are separate, the target repo's agent file (AGENTS.md, CLAUDE.md, or equivalent) is the source of truth for execution: git workflow, branch naming, commit and PR format, language. The planning repo's agent file governs only the plan files. Read the target's agent file before committing there; on conflict, it prevails for everything execution-related. If the target repo has none, report it and ask the user instead of assuming the planning repo's conventions.
+**Execution conventions.** When the planning and execution repos are separate, the target repo's agent file (AGENTS.md, CLAUDE.md, or equivalent) is the source of truth for execution: git workflow, branching, commit and PR format, language. The planning repo's agent file governs only the plan files; on conflict, the target's prevails for everything execution-related. Read it before committing there; if the target repo has none, report it and ask the user instead of assuming the planning repo's conventions.
 
 ## Extensions
 
@@ -423,11 +400,11 @@ Optional extensions live in `workplans/extend/`, one subfolder per extension. Th
 
 ## Compatibility
 
-The `version` field declares the active framework version. Plans declare their own `format` (or `format_version`, its pre-0.4.0 name — parsers accept both); validators apply the rule set matching that value, so plans from different framework versions coexist. Plans without either field are implicitly pre-0.2.1 (legacy layout, Progress first).
+The `version` field declares the active framework version. Plans declare their own `format` (read-alias `format_version`); validators apply the rule set matching that value, so plans from different framework versions coexist. Plans without either field are implicitly pre-0.2.1 (legacy layout, Progress first).
 
 ### Migration
 
-When a plan's declared format is older than the framework `version`, the agent asks the user whether to migrate it — never silently:
+When a plan's declared format is older than the framework `version`, the agent asks the user whether to migrate it — never silently. If the user declines, record the decision for the session and do not ask again.
 
 | Folder | Migration |
 |--------|-----------|
@@ -435,14 +412,11 @@ When a plan's declared format is older than the framework `version`, the agent a
 | `doing/` | Only on explicit user request |
 | `done/` | Never — historical record, immutable with its original format |
 
-- If the user declines, record the decision for the session and do not ask again.
-- A migrated plan updates its format field to the current version in the same change.
-- Migration alters frontmatter and section order only. Checkboxes, dates, and user content are preserved verbatim.
-- The CLI exposes the same operation as `workplans migrate` for reproducibility.
+Migration alters frontmatter and section order only — checkboxes, dates, and user content are preserved verbatim — and updates the format field to the current version in the same change. The CLI exposes the same operation as `workplans migrate` for reproducibility.
 
 ### Supported transitions
 
 | From | To | Transformation |
 |------|----|----------------|
 | pre-0.2.1, 0.2.x | 0.3.0 | Reorder the five H2 sections to the new layout (Objective first); set `format_version: "0.3.0"` |
-| 0.3.x | 0.4.0 | Rename `format_version` to `format` and move it first; reorder fields to the 0.4.0 order; add `priority`, `estimate`, `tracked_in` as `""` and the bare `relations:` key |
+| 0.3.x | 0.4.0 | Rename `format_version` → `format`, reorder fields to the 0.4.0 order, add `priority`/`estimate`/`tracked_in` as `""` and the bare `relations:` key |

--- a/init/workplans/RULES.md
+++ b/init/workplans/RULES.md
@@ -307,7 +307,7 @@ All 34 rules are mandatory. Ordered by criticality: **Structure** (framework int
 | 24 | Template | Plan files must not contain emojis. Use plain descriptive text instead |
 | 25 | Template | Steps that cannot be executed by an AI agent (browser checks, external dashboard configuration, manual UI testing, credential rotation) must be prefixed with `[manual]`. The agent skips them and reports to the user; Implementation describes what the user needs to do |
 | 26 | Structure | When the workplans folder is inside a Git repository (or any VCS with branch semantics), the branch for a new plan is decided explicitly before commit: declared policy in agent file → current non-main branch → ask the user. Never default silently to `main`. Outside a VCS, this rule does not apply |
-| 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language. Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
+| 27 | Template | Phase 1 (Definition) and the Closing phase translate their phase name and step text to the user's active conversation language, preserving full orthography (accents, diacritics). Only the `Phase N:` prefix, H2 headings, and `Closing Summary` (when referenced in steps) stay in English. The English template in this document is reference, not literal output |
 | 28 | Data | `relations` sub-keys are limited to `blocked_by`, `relates_to`, `supersedes`, `parent`. Targets are immutable plan `id`s, comma-separated; no titles or slugs |
 | 29 | Template | A plan with a non-empty `blocked_by` must not move to `doing/` until every referenced plan is `done`. Cycles in `blocked_by` are invalid |
 | 30 | Data | `estimate` is set when Phase 1: Definition completes, must belong to the declared `estimate_scale` token set, and is immutable once the plan is in `doing/` |
@@ -384,7 +384,7 @@ The client suffix is omitted when the agent runs directly (API, Claude Code, web
 - **Template structure** (H2 headings, `Phase` keyword) and **filenames** are always in English.
 - **Frontmatter field names** are always in English — part of the schema.
 - **User-authored content** (title, descriptions, steps, summary) follows the user's active conversation language.
-- **Orthography** must be preserved: accents, ñ, and other special characters of the user's language. UTF-8 is the encoding for Markdown files.
+- **Orthography** carries the full spelling of the user's language — accents, ñ, and any diacritics — in every content position: phase titles, step text, and body prose alike ("Definición", never "Definicion"). ASCII-only applies solely to filenames (kebab-case), never to content. UTF-8 is the encoding for Markdown files.
 
 ## Project constants
 

--- a/init/workplans/backlog/README.md
+++ b/init/workplans/backlog/README.md
@@ -14,17 +14,21 @@ A newly created plan. The agent has defined the objective, context, and phases â
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "backlog"
+priority: ""
+estimate: ""
 author: "Sebastian Serna"
 author_model: "claude-opus-4-6"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-03-05T09:30"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup

--- a/init/workplans/doing/README.md
+++ b/init/workplans/doing/README.md
@@ -14,17 +14,21 @@ The same plan now in progress. Phase 1 is complete, assignee is set, and Phase 2
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "doing"
+priority: "high"
+estimate: 5
 author: "Sebastian Serna"
 author_model: "claude-opus-4-6"
 assignee: "Sebastian Serna"
 assignee_model: "claude-sonnet-4-6"
+state: "doing"
 backlog_date: "2026-03-05T09:30"
 doing_date: "2026-03-06T14:00"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup

--- a/init/workplans/done/README.md
+++ b/init/workplans/done/README.md
@@ -10,21 +10,25 @@ Done plans should generally not be modified. If a completed plan needs rework, c
 
 ## Example plan in done
 
-The same plan fully completed. All steps are checked, done_date is set, and the Closing Summary is written.
+The same plan fully completed. All steps are checked, done_date is set, and the Closing Summary is written: a leader paragraph (exported verbatim to changelogs and tracker comments) followed by labeled subsections.
 
 ```markdown
 ---
+format: "0.4.0"
 id: 2606455842
 title: "User authentication setup"
-state: "done"
+priority: "high"
+estimate: 5
 author: "Sebastian Serna"
 author_model: "claude-opus-4-6"
 assignee: "Sebastian Serna"
 assignee_model: "claude-sonnet-4-6"
+state: "done"
 backlog_date: "2026-03-05T09:30"
 doing_date: "2026-03-06T14:00"
 done_date: "2026-03-07T18:45"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # User authentication setup
@@ -69,8 +73,23 @@ Added Express middleware in `src/middleware/auth.ts` that validates JWT on all `
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- Implemented JWT authentication with RS256, refresh token rotation, and Google OAuth (PKCE)
-- Added three auth endpoints and middleware for protected routes
-- No deviations from the original plan
-- Future work: add rate limiting on auth endpoints and support additional OAuth providers
+The web application now authenticates users with JWT sessions, email/password
+registration, and Google OAuth sign-in. Access is renewed through single-use
+refresh tokens, and every protected API route validates the session through
+shared middleware. Passwords are hashed with bcrypt and tokens are stored in
+httpOnly secure cookies.
+
+### Delivered
+- Authentication middleware protecting all API routes
+- Registration, login, and Google OAuth endpoints with integration tests
+
+### Decisions
+- RS256 signing over HS256, for key rotation support
+- Tokens in httpOnly cookies instead of localStorage
+
+### Deferred
+- Rate limiting on auth endpoints, registered in plan 2606980112
+
+### References
+- PR: https://github.com/acme/backend/pull/87
 ```

--- a/scripts/build-demo.sh
+++ b/scripts/build-demo.sh
@@ -529,7 +529,7 @@ Node.js 20 with TypeScript strict mode. ESLint with Airbnb config. PostgreSQL 16
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-The project now has a complete development foundation: repository tooling, a Docker Compose environment that runs identically for every team member, and a green CI pipeline. New features can be built and verified from day one without additional setup.
+The project now has a complete development foundation. The repository ships its tooling, a Docker Compose environment that runs identically for every team member, and a CI pipeline that verifies every push. New features can be built and verified from day one without additional setup.
 
 ### Delivered
 - Repository tooling and linting configuration
@@ -671,7 +671,7 @@ Health check at `/health` reports database, Redis, and external service status. 
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-All services now emit structured logs with request ID correlation, and the health check reports a degraded state when dependencies are slow. Dashboards expose p50, p95, and p99 latency with alert thresholds, and alerts fire when the error rate exceeds 5% over 5 minutes.
+All services now emit structured logs with request ID correlation. The health check reports a degraded state when dependencies are slow. Dashboards expose p50, p95, and p99 latency with alert thresholds, and alerts fire when the error rate exceeds 5% over 5 minutes.
 
 ### Delivered
 - Winston logging with request ID correlation across all services
@@ -744,7 +744,7 @@ Staging auto-deploys on merge to main via GitHub Actions. Production deploys req
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-The CI pipeline now completes in 3.5 minutes, down from 12, through caching and parallel jobs. Merges to main deploy to staging automatically, production deploys sit behind an approval gate, and a documented rollback mechanism is in place.
+The CI pipeline now completes in 3.5 minutes, down from 12, through caching and parallel jobs. Merges to main deploy to staging automatically, while production deploys sit behind an approval gate. A documented rollback mechanism is in place.
 
 ### Delivered
 - Cached, parallelized CI pipeline

--- a/scripts/build-demo.sh
+++ b/scripts/build-demo.sh
@@ -2,7 +2,7 @@
 # ─────────────────────────────────────────────────────────────────
 # build-demo.sh
 # Regenerates demo/workplans from init/workplans and creates
-# example plan files for all three states (v0.3.0 format).
+# example plan files for all three states (v0.4.0 format).
 #
 # Usage: ./scripts/build-demo.sh
 # ─────────────────────────────────────────────────────────────────
@@ -25,17 +25,22 @@ echo "==> Creating backlog plans..."
 
 cat <<'EOF' > "$DEMO/backlog/2601551600_user-auth-setup.md"
 ---
+format: "0.4.0"
 id: 2601551600
 title: "User authentication setup"
-state: "backlog"
+priority: "high"
+estimate: 5
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-01-15T14:20"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  blocked_by: "2602836000"
 ---
 
 # User authentication setup
@@ -87,17 +92,21 @@ EOF
 
 cat <<'EOF' > "$DEMO/backlog/2602836000_notification-system.md"
 ---
+format: "0.4.0"
 id: 2602836000
 title: "Email notification system"
-state: "backlog"
+priority: "high"
+estimate: 3
 author: "sebastianserna"
 author_model: "mistral-large"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-01T09:15"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Email notification system
@@ -141,17 +150,21 @@ EOF
 
 cat <<'EOF' > "$DEMO/backlog/2604739600_search-functionality.md"
 ---
+format: "0.4.0"
 id: 2604739600
 title: "Full-text search functionality"
-state: "backlog"
+priority: "medium"
+estimate: 8
 author: "sebastianserna"
 author_model: ""
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-20T15:45"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Full-text search functionality
@@ -194,17 +207,22 @@ EOF
 
 cat <<'EOF' > "$DEMO/backlog/2604952200_role-permissions.md"
 ---
+format: "0.4.0"
 id: 2604952200
 title: "Role-based permissions"
-state: "backlog"
+priority: "medium"
+estimate: 5
 author: "sebastianserna"
 author_model: "gemini-2.5-pro"
 assignee: "alexgarcia"
 assignee_model: "gpt-4o"
+state: "backlog"
 backlog_date: "2026-02-22T09:25"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  relates_to: "2601551600"
 ---
 
 # Role-based permissions
@@ -260,17 +278,21 @@ echo "==> Creating doing plans..."
 
 cat <<'EOF' > "$DEMO/doing/2601557600_dashboard-redesign.md"
 ---
+format: "0.4.0"
 id: 2601557600
 title: "Dashboard redesign"
-state: "doing"
+priority: "high"
+estimate: 8
 author: "sebastianserna"
 author_model: "claude-opus-4, gemini-pro"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "doing"
 backlog_date: "2026-01-20T10:00"
 doing_date: "2026-02-10T09:30"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Dashboard redesign
@@ -323,17 +345,21 @@ EOF
 
 cat <<'EOF' > "$DEMO/doing/2603334200_api-v2-endpoints.md"
 ---
+format: "0.4.0"
 id: 2603334200
 title: "API v2 endpoints"
-state: "doing"
+priority: "high"
+estimate: 8
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: "alexgarcia"
 assignee_model: "claude-opus-4"
+state: "doing"
 backlog_date: "2026-02-05T11:00"
 doing_date: "2026-02-18T09:00"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # API v2 endpoints
@@ -377,17 +403,22 @@ EOF
 
 cat <<'EOF' > "$DEMO/doing/2603440500_websocket-realtime.md"
 ---
+format: "0.4.0"
 id: 2603440500
 title: "WebSocket real-time updates"
-state: "doing"
+priority: "medium"
+estimate: 5
 author: "sebastianserna"
 author_model: "deepseek-v3"
 assignee: "alexgarcia"
 assignee_model: "grok-3"
+state: "doing"
 backlog_date: "2026-02-05T14:00"
 doing_date: "2026-02-20T10:30"
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  relates_to: "2603334200"
 ---
 
 # WebSocket real-time updates
@@ -444,17 +475,21 @@ echo "==> Creating done plans..."
 
 cat <<'EOF' > "$DEMO/done/2600532400_project-setup.md"
 ---
+format: "0.4.0"
 id: 2600532400
 title: "Initial project setup"
-state: "done"
+priority: ""
+estimate: 3
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "done"
 backlog_date: "2026-01-05T09:00"
 doing_date: "2026-01-10T10:00"
 done_date: "2026-01-30T14:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Initial project setup
@@ -494,24 +529,35 @@ Node.js 20 with TypeScript strict mode. ESLint with Airbnb config. PostgreSQL 16
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- All tooling and CI pipeline set up and verified
-- CI pipeline is green, team can start building features
-- Docker Compose environment works for all team members
+The project now has a complete development foundation: repository tooling, a Docker Compose environment that runs identically for every team member, and a green CI pipeline. New features can be built and verified from day one without additional setup.
+
+### Delivered
+- Repository tooling and linting configuration
+- Docker Compose development environment
+- CI pipeline running on every push
+
+### Verification
+- CI green; environment verified by every team member
 EOF
 
 cat <<'EOF' > "$DEMO/done/2601036900_database-schema.md"
 ---
+format: "0.4.0"
 id: 2601036900
 title: "Database schema design"
-state: "done"
+priority: "high"
+estimate: 5
 author: "sebastianserna"
 author_model: "gpt-4o"
 assignee: "alexgarcia"
 assignee_model: "gpt-4o"
+state: "done"
 backlog_date: "2026-01-10T10:15"
 doing_date: "2026-01-20T09:00"
 done_date: "2026-02-08T11:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
+  blocked_by: "2600532400"
 ---
 
 # Database schema design
@@ -551,25 +597,32 @@ PostgreSQL with UUIDs as primary keys. All tables include `created_at` and `upda
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- Schema finalized and deployed to staging
-- All migrations run cleanly on fresh databases
-- Seed data populates correctly for development
-- Foreign key constraints and query performance verified
+The database schema is finalized and deployed to staging. Migrations run cleanly on fresh databases and seed data populates correctly for development. Foreign key constraints and query performance are verified.
+
+### Delivered
+- Normalized schema with migrations and seed data
+
+### Verification
+- Fresh-database migration runs, constraint checks, and query benchmarks
 EOF
 
 cat <<'EOF' > "$DEMO/done/2601632400_logging-monitoring.md"
 ---
+format: "0.4.0"
 id: 2601632400
 title: "Logging and monitoring setup"
-state: "done"
+priority: "medium"
+estimate: 5
 author: "sebastianserna"
 author_model: "claude-opus-4"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "done"
 backlog_date: "2026-01-20T11:00"
 doing_date: "2026-02-01T10:00"
 done_date: "2026-02-15T15:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Logging and monitoring setup
@@ -618,25 +671,33 @@ Health check at `/health` reports database, Redis, and external service status. 
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- Winston logging with request ID correlation deployed across all services
-- Health check correctly reports degraded state when dependencies are slow
-- Grafana dashboards show p50, p95, p99 latency with alert thresholds
-- Alerts fire when error rate exceeds 5% over 5 minutes
+All services now emit structured logs with request ID correlation, and the health check reports a degraded state when dependencies are slow. Dashboards expose p50, p95, and p99 latency with alert thresholds, and alerts fire when the error rate exceeds 5% over 5 minutes.
+
+### Delivered
+- Winston logging with request ID correlation across all services
+- Grafana dashboards and alerting rules
+
+### Verification
+- Degraded-state reporting and alert firing tested end to end
 EOF
 
 cat <<'EOF' > "$DEMO/done/2602250400_ci-pipeline.md"
 ---
+format: "0.4.0"
 id: 2602250400
 title: "CI/CD pipeline improvements"
-state: "done"
+priority: "medium"
+estimate: 3
 author: "sebastianserna"
 author_model: "mistral-large"
 assignee: "alexgarcia"
 assignee_model: "claude-sonnet-4"
+state: "done"
 backlog_date: "2026-01-25T09:30"
 doing_date: "2026-02-10T08:30"
 done_date: "2026-02-20T10:10"
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # CI/CD pipeline improvements
@@ -683,10 +744,14 @@ Staging auto-deploys on merge to main via GitHub Actions. Production deploys req
 Validate the implementation with the user and write the Closing Summary. Once complete, the plan is ready to move to done.
 
 ## Closing Summary
-- CI pipeline reduced from 12 min to 3.5 min with caching and parallel jobs
-- Staging auto-deploy verified and working on merge to main
-- Production deploy with approval gate tested successfully
-- Rollback mechanism documented and tested
+The CI pipeline now completes in 3.5 minutes, down from 12, through caching and parallel jobs. Merges to main deploy to staging automatically, production deploys sit behind an approval gate, and a documented rollback mechanism is in place.
+
+### Delivered
+- Cached, parallelized CI pipeline
+- Staging auto-deploy and gated production deploy
+
+### Verification
+- Staging auto-deploy, production approval gate, and rollback tested
 EOF
 
 # ─── Backlog plans (defined, pending user validation) ───
@@ -694,17 +759,21 @@ echo "==> Creating backlog plans (pending user validation)..."
 
 cat <<'EOF' > "$DEMO/backlog/2604141400_api-rate-limiting.md"
 ---
+format: "0.4.0"
 id: 2604141400
 title: "API rate limiting strategy"
-state: "backlog"
+priority: "low"
+estimate: 3
 author: "sebastianserna"
 author_model: ""
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-10T11:30"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # API rate limiting strategy
@@ -748,17 +817,21 @@ EOF
 
 cat <<'EOF' > "$DEMO/backlog/2604655800_dark-mode-design.md"
 ---
+format: "0.4.0"
 id: 2604655800
 title: "Dark mode design system"
-state: "backlog"
+priority: ""
+estimate: 2
 author: "sebastianserna"
 author_model: "gpt-4o"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-15T15:30"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # Dark mode design system
@@ -809,17 +882,21 @@ EOF
 
 cat <<'EOF' > "$DEMO/backlog/2605639600_file-upload-system.md"
 ---
+format: "0.4.0"
 id: 2605639600
 title: "File upload system"
-state: "backlog"
+priority: ""
+estimate: 5
 author: "sebastianserna"
 author_model: "grok-3"
 assignee: ""
 assignee_model: ""
+state: "backlog"
 backlog_date: "2026-02-25T11:00"
 doing_date: ""
 done_date: ""
-format_version: "0.3.0"
+tracked_in: ""
+relations:
 ---
 
 # File upload system

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -2,18 +2,24 @@
 # ─────────────────────────────────────────────────────────────────
 # validate.sh
 # Validates a workplans directory. Format-aware: applies the rule set
-# matching each plan's format_version (0.2.x legacy layout, with
-# Progress above Objective, vs 0.3.0+ new layout, with Objective
-# above Progress).
+# matching each plan's declared format (`format`, or its pre-0.4.0
+# alias `format_version`): 0.2.x legacy layout (Progress above
+# Objective), 0.3.x new layout (Objective above Progress), 0.4.0
+# frontmatter (format first, triage fields, tracked_in, relations).
 #
 # Usage: ./scripts/validate.sh <workplans-dir>
 #
 # Checks:
-#   1. Frontmatter: id first field, required fields, state matches folder
+#   1. Frontmatter: first field, required fields and order per format,
+#      state matches folder, triage/relations value sets
 #   2. Template: allowed sections only, no deprecated sections,
-#      section order matches the format_version layout
+#      section order matches the format layout, Closing Summary
+#      leader paragraph on 0.4.0+ done plans
 #   3. File naming: YYDDDsssss_description.md pattern
-#   4. Structure: RULES.md exists with version/work_on fields, READMEs exist
+#   4. Structure: RULES.md exists with version field, READMEs exist,
+#      no foreign subfolders
+#   5. Encoding: valid UTF-8, heuristic orthography warnings (accent
+#      dropping in Spanish content)
 # ─────────────────────────────────────────────────────────────────
 
 set -e
@@ -66,9 +72,37 @@ version_ge() {
   [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n 1)" == "$2" ]]
 }
 
+# Declared plan format: `format` (0.4.0+) with `format_version` as read-alias
+get_format() {
+  local f
+  f=$(get_field "$1" "format")
+  [[ -z "$f" ]] && f=$(get_field "$1" "format_version")
+  echo "$f"
+}
+
 get_first_field() {
   # Get the first field name after the opening ---
   sed -n '2p' "$1" | sed 's/:.*//'
+}
+
+# Top-level frontmatter field names in file order (indented sub-keys excluded)
+get_fm_fields() {
+  awk '
+    NR == 1 && /^---$/ { in_fm = 1; next }
+    in_fm && /^---$/ { exit }
+    in_fm && /^[a-z_]+:/ { sub(/:.*/, ""); print }
+  ' "$1" 2>/dev/null
+}
+
+# Indented sub-keys of relations
+get_relations_keys() {
+  awk '
+    NR == 1 && /^---$/ { in_fm = 1; next }
+    in_fm && /^---$/ { exit }
+    in_fm && /^relations:/ { in_rel = 1; next }
+    in_rel && /^[a-z_]+:/ { exit }
+    in_rel && /^[ ]+[a-z_]+:/ { gsub(/^[ ]+/, ""); sub(/:.*/, ""); print }
+  ' "$1" 2>/dev/null
 }
 
 get_h1() {
@@ -96,14 +130,32 @@ if [[ -f "$WORKPLANS_DIR/RULES.md" ]]; then
   fi
 
   rules_work_on=$(get_field "$WORKPLANS_DIR/RULES.md" "work_on")
-  if [[ -n "$rules_work_on" ]]; then
-    pass "RULES.md — work_on field present ($rules_work_on)"
+  if [[ -n "$rules_version" ]] && version_ge "$rules_version" "0.4.0"; then
+    if [[ -n "$rules_work_on" ]]; then
+      warn "RULES.md — work_on moved to the root README frontmatter in 0.4.0"
+    else
+      pass "RULES.md — no work_on (project constants live in the root README)"
+    fi
   else
-    warn "RULES.md — missing work_on field (defaults to \".\")"
+    if [[ -n "$rules_work_on" ]]; then
+      pass "RULES.md — work_on field present ($rules_work_on)"
+    else
+      warn "RULES.md — missing work_on field (defaults to \".\")"
+    fi
   fi
 else
   fail "RULES.md not found"
 fi
+
+# Check for foreign subfolders (rule 34: single-project layout)
+for entry in "$WORKPLANS_DIR"/*/; do
+  [[ ! -d "$entry" ]] && continue
+  dname=$(basename "$entry")
+  case "$dname" in
+    backlog|doing|done|extend) ;;
+    *) fail "Foreign subfolder in workplans/: $dname/ (rule 34: single-project layout)" ;;
+  esac
+done
 
 # Check state folders
 for folder in backlog doing done; do
@@ -186,12 +238,18 @@ for folder in backlog doing done; do
       continue
     fi
 
-    # Check id is first field
+    # Check first field per format: `format` in 0.4.0+, `id` before
+    plan_format=$(get_format "$file")
     first_field=$(get_first_field "$file")
-    if [[ "$first_field" == "id" ]]; then
-      pass "$folder/$bn — id is first field"
+    if [[ -n "$plan_format" ]] && version_ge "$plan_format" "0.4.0"; then
+      expected_first="format"
     else
-      fail "$folder/$bn — id is not first field (found: $first_field)"
+      expected_first="id"
+    fi
+    if [[ "$first_field" == "$expected_first" ]]; then
+      pass "$folder/$bn — $expected_first is first field"
+    else
+      fail "$folder/$bn — $expected_first is not first field (found: $first_field)"
     fi
 
     # Check id matches filename
@@ -213,12 +271,60 @@ for folder in backlog doing done; do
       fail "$folder/$bn — state mismatch: frontmatter=$fm_state folder=$folder"
     fi
 
-    # Check required fields exist
-    for field in title state author author_model assignee assignee_model backlog_date doing_date done_date format_version; do
+    # Check required fields exist (set depends on format)
+    if [[ -n "$plan_format" ]] && version_ge "$plan_format" "0.4.0"; then
+      required_fields="format title priority estimate state author author_model assignee assignee_model backlog_date doing_date done_date tracked_in relations"
+    else
+      required_fields="format_version title state author author_model assignee assignee_model backlog_date doing_date done_date"
+    fi
+    for field in $required_fields; do
       if ! grep -q "^${field}:" "$file"; then
         fail "$folder/$bn — missing field: $field"
       fi
     done
+
+    # 0.4.0 rule set: field order, triage values, relations types
+    if [[ -n "$plan_format" ]] && version_ge "$plan_format" "0.4.0"; then
+      expected_fields="format id title priority estimate author author_model assignee assignee_model state backlog_date doing_date done_date tracked_in relations"
+      actual_fields=$(get_fm_fields "$file" | tr '\n' ' ' | sed 's/ *$//')
+      if [[ "$actual_fields" == "$expected_fields" ]]; then
+        pass "$folder/$bn — frontmatter fields in 0.4.0 order"
+      else
+        fail "$folder/$bn — frontmatter fields out of 0.4.0 order: [$actual_fields]"
+      fi
+
+      prio=$(get_field "$file" "priority")
+      case "$prio" in
+        urgent|high|medium|low|"") pass "$folder/$bn — priority value OK ('${prio}')" ;;
+        *) fail "$folder/$bn — invalid priority: '$prio'" ;;
+      esac
+
+      est=$(get_field "$file" "estimate")
+      scale=$(get_field "$WORKPLANS_DIR/README.md" "estimate_scale")
+      [[ -z "$scale" ]] && scale="fibonacci"
+      if [[ -n "$est" ]]; then
+        case "$scale" in
+          fibonacci) scale_tokens=" 1 2 3 5 8 13 21 " ;;
+          tshirt)    scale_tokens=" xs s m l xl " ;;
+          *)         scale_tokens="" ;;
+        esac
+        if [[ -z "$scale_tokens" ]]; then
+          warn "$folder/$bn — unknown estimate_scale '$scale'; estimate not validated"
+        elif [[ "$scale_tokens" == *" $est "* ]]; then
+          pass "$folder/$bn — estimate '$est' valid in $scale scale"
+        else
+          fail "$folder/$bn — estimate '$est' not in $scale scale"
+        fi
+      fi
+
+      while IFS= read -r rk; do
+        [[ -z "$rk" ]] && continue
+        case "$rk" in
+          blocked_by|relates_to|supersedes|parent) pass "$folder/$bn — relations type '$rk' OK" ;;
+          *) fail "$folder/$bn — invalid relations type: $rk" ;;
+        esac
+      done <<< "$(get_relations_keys "$file")"
+    fi
 
     # Check H1 matches title field
     plan_title=$(get_field "$file" "title")
@@ -259,14 +365,14 @@ for folder in backlog doing done; do
       done
     done <<< "$sections"
 
-    # Select expected section order based on format_version
-    plan_fv=$(get_field "$file" "format_version")
+    # Select expected section order based on the declared format
+    plan_fv=$(get_format "$file")
     if [[ -n "$plan_fv" ]] && version_ge "$plan_fv" "0.3.0"; then
       expected_order=("Objective" "Progress" "Context" "Implementation" "Closing Summary")
-      layout_label="new (format_version $plan_fv >= 0.3.0)"
+      layout_label="new (format $plan_fv >= 0.3.0)"
     else
       expected_order=("Progress" "Objective" "Context" "Implementation" "Closing Summary")
-      layout_label="legacy (format_version ${plan_fv:-unset} < 0.3.0)"
+      layout_label="legacy (format ${plan_fv:-unset} < 0.3.0)"
     fi
     section_array=()
     while IFS= read -r s; do
@@ -332,6 +438,49 @@ for folder in backlog doing done; do
       pass "$folder/$bn — Closing phase present"
     else
       fail "$folder/$bn — missing mandatory Closing phase"
+    fi
+
+    # 0.4.0+ done plans: Closing Summary opens with the leader paragraph
+    if [[ "$folder" == "done" ]] && [[ -n "$plan_fv" ]] && version_ge "$plan_fv" "0.4.0"; then
+      cs_first=$(awk '/^## Closing Summary/{f=1;next} /^## /{f=0} f' "$file" | grep -v '^[[:space:]]*$' | head -1)
+      if [[ -z "$cs_first" ]]; then
+        fail "$folder/$bn — Closing Summary is empty in a done plan"
+      elif [[ "$cs_first" == _* ]]; then
+        fail "$folder/$bn — Closing Summary still has the placeholder in a done plan"
+      elif [[ "$cs_first" == "#"* || "$cs_first" == "-"* || "$cs_first" == "*"* ]]; then
+        fail "$folder/$bn — Closing Summary must open with the leader paragraph (found heading or bullet first)"
+      else
+        pass "$folder/$bn — Closing Summary leader paragraph present"
+      fi
+    fi
+  done
+done
+
+# ─── Encoding and orthography validation ─────────────────────────
+echo ""
+echo "=== Encoding and orthography validation ==="
+
+# Curated accent-dropped Spanish forms seen in real corpora (warnings only)
+ORTHO_RE='\b([Dd]efinicion|[Ee]jecucion|[Vv]alidacion|[Ii]mplementacion|[Dd]escripcion|[Cc]onfiguracion|[Mm]igracion|[Cc]reacion|[Ii]ntegracion|[Dd]ocumentacion|[Ee]specificacion|[Ss]incronizacion|[Pp]arrafo|[Cc]ompactacion|[Rr]efinacion)\b'
+
+for folder in backlog doing done; do
+  dir="$WORKPLANS_DIR/$folder"
+  [[ ! -d "$dir" ]] && continue
+
+  for file in "$dir"/*.md; do
+    [[ ! -f "$file" ]] && continue
+    bn=$(basename "$file")
+    [[ "$bn" == "README.md" ]] && continue
+
+    if perl -e 'use Encode; local $/; open my $fh, "<:raw", $ARGV[0] or exit 1; my $d = <$fh>; eval { Encode::decode("UTF-8", $d, Encode::FB_CROAK) }; exit($@ ? 1 : 0)' "$file"; then
+      pass "$folder/$bn — valid UTF-8"
+    else
+      fail "$folder/$bn — invalid UTF-8 encoding"
+    fi
+
+    ortho_hits=$(perl -CSD -ne "while (/$ORTHO_RE/g) { print \"\$1 \" }" "$file" 2>/dev/null | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
+    if [[ -n "$ortho_hits" ]]; then
+      warn "$folder/$bn — possible missing accents: ${ortho_hits% }"
     fi
   done
 done

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -457,6 +457,13 @@ for folder in backlog doing done; do
         fail "$folder/$bn — Closing Summary must open with the leader paragraph (found heading or bullet first)"
       else
         pass "$folder/$bn — Closing Summary leader paragraph present"
+
+        # Leader length: 3-6 sentences (heuristic count, warning only)
+        cs_leader=$(awk '/^## Closing Summary/{f=1;next} f && /^#/{exit} f && NF==0 && started{exit} f && NF>0{print; started=1}' "$file")
+        n_sent=$(printf '%s' "$cs_leader" | perl -0777 -ne 'my $n = () = /[.!?](?=\s|$)/g; print $n' 2>/dev/null)
+        if [[ -n "$n_sent" ]] && (( n_sent < 3 || n_sent > 6 )); then
+          warn "$folder/$bn — leader paragraph has $n_sent sentence(s); the rule says 3-6"
+        fi
       fi
 
       # Subsection labels must be H3 headings, not plain-text lines

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -464,6 +464,15 @@ for folder in backlog doing done; do
         if [[ -n "$n_sent" ]] && (( n_sent < 3 || n_sent > 6 )); then
           warn "$folder/$bn — leader paragraph has $n_sent sentence(s); the rule says 3-6"
         fi
+
+        # Leader language: if the plan's own prose carries accented characters
+        # but the leader has none and reads as English, flag it (warning only)
+        title_accented=$(get_field "$file" "title" | perl -CSD -Mutf8 -ne 'print /[áéíóúñÁÉÍÓÚÑüÜ]/ ? 1 : 0')
+        leader_accents=$(printf '%s' "$cs_leader" | perl -CSD -Mutf8 -ne '$n += () = /[áéíóúñÁÉÍÓÚÑüÜ]/g; END{print $n+0}')
+        leader_en=$(printf '%s' "$cs_leader" | perl -0777 -ne 'my %s; $s{lc $1}++ while /\b(the|and|with|from|was|were|is|are)\b/gi; print scalar keys %s')
+        if [[ "$title_accented" == "1" ]] && (( leader_accents == 0 )) && (( leader_en >= 3 )); then
+          warn "$folder/$bn — leader paragraph may not be in the plan's language (title is accented, leader reads as English)"
+        fi
       fi
 
       # Subsection labels must be H3 headings, not plain-text lines

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -433,11 +433,17 @@ for folder in backlog doing done; do
 
     # Check Closing phase exists (last phase, title follows user's language)
     # Get the last ### Phase N: heading and check it's the closing phase
-    last_phase=$(grep "### Phase [0-9]*:" "$file" | tail -1)
+    last_phase=$(grep "### Phase [0-9][0-9]*:" "$file" | tail -1)
     if [[ -n "$last_phase" ]]; then
       pass "$folder/$bn — Closing phase present"
     else
       fail "$folder/$bn — missing mandatory Closing phase"
+    fi
+
+    # Phase headings must carry a number: a literal "Phase N:" is template
+    # imitation, not a valid heading
+    if grep -qE "^#+ Phase [^0-9:]+:" "$file"; then
+      fail "$folder/$bn — phase heading without a number (literal 'Phase N:'?)"
     fi
 
     # 0.4.0+ done plans: Closing Summary opens with the leader paragraph
@@ -451,6 +457,12 @@ for folder in backlog doing done; do
         fail "$folder/$bn — Closing Summary must open with the leader paragraph (found heading or bullet first)"
       else
         pass "$folder/$bn — Closing Summary leader paragraph present"
+      fi
+
+      # Subsection labels must be H3 headings, not plain-text lines
+      if awk '/^## Closing Summary/{f=1;next} /^## /{f=0} f' "$file" \
+        | grep -qE '^(Delivered|Decisions|Verification|Deferred|References):?[[:space:]]*$'; then
+        fail "$folder/$bn — Closing Summary label written as plain text; use an H3 heading (### Label)"
       fi
     fi
   done

--- a/templates/README.md
+++ b/templates/README.md
@@ -7,7 +7,7 @@ npx workplans list             # see this catalog
 npx workplans add <template>   # copy one into workplans/backlog/ with a fresh id
 ```
 
-`add` rewrites the frontmatter on the way in: new timestamp `id`, `state: "backlog"`, `backlog_date` now, and `format_version` matching the user's local RULES.md. Phase 1: Definition arrives unchecked on purpose — every template must be refined against the real project before execution (that is the entry gate).
+`add` rewrites the frontmatter on the way in: new timestamp `id`, `state: "backlog"`, `backlog_date` now, and the format matching the user's local RULES.md — on a 0.4.0+ framework the template is migrated to the current contract (field order, `format` first, triage and sync fields) as it lands. Phase 1: Definition arrives unchecked on purpose — every template must be refined against the real project before execution (that is the entry gate).
 
 ## Contributing a template
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -12,7 +12,7 @@ npx workplans add <template>   # copy one into workplans/backlog/ with a fresh i
 ## Contributing a template
 
 1. Create `templates/<name>.md` — the kebab-case filename is the template id.
-2. The file is a complete, valid plan per [RULES.md](../init/workplans/RULES.md): five H2 sections in the 0.3+ order, mandatory Phase 1: Definition and Closing phase, no emojis. Use placeholder values in the frontmatter (`id: 0000000000`, empty dates) — the CLI rewrites them.
+2. The file is a complete, valid plan per [RULES.md](../init/workplans/RULES.md): five H2 sections in the current order (Objective first), mandatory Phase 1: Definition and Closing phase, no emojis. Use placeholder values in the frontmatter (`id: 0000000000`, empty dates) — the CLI rewrites them and migrates the frontmatter to the installed format on the way in.
 3. Write the Context section as instructions for replacement: what the user should fill in during Phase 1.
 4. Steps an AI agent cannot execute (browser checks, credential configuration) carry the `[manual]` prefix.
 5. Add an entry to `index.json` with `name`, `title` (must match the plan title) and a one-line `description`.


### PR DESCRIPTION
Closes #6, #13, #26, #60, #61, #62, #63, #64, #65, #66, #78 (milestone [v0.4.0](https://github.com/agnostical/workplans/milestone/7)) and #69, #70 (milestone [cli-v0.3.0](https://github.com/agnostical/workplans/milestone/10)). Format 0.4.0 is the tracker-ready contract; commits are atomized per issue.

## Format spec (RULES.md)

- **Frontmatter 0.4.0** (#64): `format_version` renamed to `format` and moved first — it is the discriminator that says which schema governs the file. Parsers accept `format_version` as read-alias; new plans write `format`. Fixed 16-line field order; scalars empty to `""`.
- **Typed relations** (#61): one nested `relations` field (`blocked_by`, `relates_to`, `supersedes`, `parent`), id-pure references, derived inverses, bare-key empty form, `blocked_by` gating and cycle rejection.
- **Triage** (#6, #63): `estimate` with a per-project declarable scale (`fibonacci` default, `tshirt`), set when Phase 1 completes, immutable in `doing/`, top band as split signal; `priority` (`urgent`/`high`/`medium`/`low`/`""`), mutable, soft selection that never overrides blocking.
- **Sync contract** (#62): `tracked_in` mirror URL(s), the `plan:<id>` marker as idempotency key (read-alias `workplan:<id>`), self-healing field, one mirror per tracker, source-of-truth split between markdown and tracker.
- **Structured Closing Summary** (#64): mandatory leader paragraph with seven portability rules, the literal export unit for changelogs and mirror closing comments; recommended non-exclusive subsection vocabulary (`Delivered`, `Decisions`, `Verification`, `Deferred`, `References`), normative status per label, ~40-line budget, banned noise; extraction contract documented (the framework ships no CHANGELOG.md).
- **Execution sequence** (#13): optional lettered grouping at the end of Progress for 5+ phase plans.
- **Project constants** (#65): `work_on`, `tracker`, `estimate_scale` live in the root README frontmatter, all optional with defaults; the root README is user-owned after init; RULES.md frontmatter carries framework metadata only.
- **Execution conventions** (#60): the target repo's agent file is the source of truth for execution; explicit precedence on conflict.
- **Migration behavior** (#66): agents ask before migrating, backlog by default, doing on request, done never; documented transition table (0.2.x -> 0.3.0, 0.3.x -> 0.4.0).
- **Orthography** (#78): full user-language spelling (accents, diacritics) in every content position; ASCII only for filenames; UTF-8 required.
- Branch rule: a planning-only repo may declare a main-only policy.
- Rules table grows 27 -> 34, all in the compact one-assertion style.

## Docs

- Framework README: project constants rationale, Closing Summary voice guide with the canonical English example, format rename, target-repo conventions.
- Repo README: 0.4.0 frontmatter example, tracker-ready feature bullet, and the Extensions section restored now that the board is public (#26).
- State-folder example plans migrated to 0.4.0, including a done example with an exemplary Closing Summary (leader paragraph + References).
- The 14-plan demo corpus (`build-demo.sh` + `demo/workplans`) regenerated in 0.4.0: triage values on every plan, sample `blocked_by`/`relates_to` relations, and leader-paragraph Closing Summaries on all done plans.

## Validators

`scripts/validate.sh` applies the rule set per declared format: `format` alias handling, first-field and field-order checks, priority/estimate value sets against the declared scale, relations types, leader-paragraph presence and H3 subsection labels on 0.4.0 done plans, numbered phase headings (a literal "Phase N:" is template imitation), foreign-subfolder detection, UTF-8 assertion, and heuristic accent-dropping warnings (#78). The last two checks — plus a 3-6 sentence heuristic warning on the leader paragraph and three spec clarifications (literal `Phase N` never allowed, leader prose in the user's language, Phase 1 checkbox state at creation) — come from an informal multi-model validation run against this spec (see #27). Verified against three corpora: the init template, the 14-plan demo, and a 25-plan mixed-version repository (0.2.x/0.3.x plans coexisting with 0.4.0 rules).

**Spec budget note**: RULES.md lands at 427 lines / ~6.4k tokens against the ~500-line / ~6k-token target (main carried ~4.0k; the ten issues add ~2.3k of contract after two compaction passes on the new sections). The line budget holds; closing the remaining token gap requires compacting pre-existing content, which stays gated on the evals harness (#27).

## CLI 0.3.0

- **`update` ownership fix** (#69): the root README leaves `SYSTEM_FILES` — never overwritten, created only if missing; one-time migration moves `work_on` from RULES.md frontmatter into the README frontmatter.
- **`migrate` command** (#70): backlog by default, `--doing` opt-in, done never; documented per-version transitions; `--dry-run`; result validated against the 0.4.0 contract including estimate tokens; content sections preserved verbatim.
- **`add` transition fix**: on a 0.4.0+ framework, templates are migrated to the 0.4.0 contract on the way in instead of stamping a version their shape would contradict.
- Router gains per-command flag support. Test suite: 36 tests, all offline.

## Verification

- `npm test` in `cli/`: 36/36 passing.
- `scripts/validate.sh` on `init/workplans` and the regenerated 0.4.0 `demo/workplans`: 0 errors, 0 warnings.
- Mixed-version corpus validation: 0 errors (8 expected orthography warnings on active plans pending normalization).

The `workplans@0.3.0` npm publish and the dogfood run (`update` + `migrate` on a real mixed-version repository) follow the merge, per the release sequence.
